### PR TITLE
driver:pcie: enable top intc of chip1 for server

### DIFF
--- a/arch/riscv/boot/dts/sophgo/mango-pcie-2rc.dtsi
+++ b/arch/riscv/boot/dts/sophgo/mango-pcie-2rc.dtsi
@@ -17,10 +17,11 @@
 		device-id = /bits/ 16 <0x2042>;
 		pcie-id = /bits/ 16 <0x1>;
 		link-id = /bits/ 16 <0x0>;
-		top-intc-used = <0>;
-		interrupt-parent = <&intc>;
-		interrupts = <SOC_PERIPHERAL_IRQ(123) IRQ_TYPE_LEVEL_HIGH>;
-		interrupt-names = "msi";
+		top-intc-used = <1>;
+		top-intc-id = <0>;
+		interrupt-parent = <&intc1>;
+		//interrupts = <SOC_PERIPHERAL_IRQ(123) IRQ_TYPE_LEVEL_HIGH>;
+		//interrupt-names = "msi";
 		reg = <0x70 0x62000000  0x0 0x02000000>,
 		      <0x48 0x00000000  0x0 0x00001000>;
 		reg-names = "reg", "cfg";
@@ -54,10 +55,11 @@
 		device-id = /bits/ 16 <0x2042>;
 		pcie-id = /bits/ 16 <0x0>;
 		link-id = /bits/ 16 <0x0>;
-		top-intc-used = <0>;
-		interrupt-parent = <&intc>;
-		interrupts = <SOC_PERIPHERAL_IRQ(346) IRQ_TYPE_LEVEL_HIGH>;
-		interrupt-names = "msi";
+		top-intc-used = <1>;
+		top-intc-id = <1>;
+		interrupt-parent = <&intc2>;
+		//interrupts = <SOC_PERIPHERAL_IRQ(346) IRQ_TYPE_LEVEL_HIGH>;
+		//interrupt-names = "msi";
 		reg = <0xf0 0x60000000  0x0 0x02000000>,
 		      <0xc0 0x00000000  0x0 0x00001000>;
 		reg-names = "reg", "cfg";

--- a/arch/riscv/boot/dts/sophgo/mango-pcie-3rc-v2.dtsi
+++ b/arch/riscv/boot/dts/sophgo/mango-pcie-3rc-v2.dtsi
@@ -18,6 +18,7 @@
 		pcie-id = /bits/ 16 <0x0>;
 		link-id = /bits/ 16 <0x0>;
 		top-intc-used = <1>;
+		top-intc-id = <0>;
 		interrupt-parent = <&intc1>;
 		reg = <0x70 0x60000000  0x0 0x02000000>,
 		      <0x40 0x00000000  0x0 0x00001000>;

--- a/arch/riscv/boot/dts/sophgo/mango-pcie-3rc.dtsi
+++ b/arch/riscv/boot/dts/sophgo/mango-pcie-3rc.dtsi
@@ -55,6 +55,7 @@
 		pcie-id = /bits/ 16 <0x0>;
 		link-id = /bits/ 16 <0x1>;
 		top-intc-used = <1>;
+		top-intc-id = <0>;
 		interrupt-parent = <&intc1>;
 		reg = <0x44 0x00000000  0x0 0x00001000>;
 		reg-names = "cfg";

--- a/arch/riscv/boot/dts/sophgo/mango-pcie-4rc.dtsi
+++ b/arch/riscv/boot/dts/sophgo/mango-pcie-4rc.dtsi
@@ -55,6 +55,7 @@
 		pcie-id = /bits/ 16 <0x0>;
 		link-id = /bits/ 16 <0x1>;
 		top-intc-used = <1>;
+		top-intc-id = <0>;
 		interrupt-parent = <&intc1>;
 		reg = <0x44 0x00000000  0x0 0x00001000>;
 		reg-names = "cfg";
@@ -126,6 +127,7 @@
 		pcie-id = /bits/ 16 <0x1>;
 		link-id = /bits/ 16 <0x1>;
 		top-intc-used = <1>;
+		top-intc-id = <0>;
 		interrupt-parent = <&intc1>;
 		reg = <0x4c 0x00000000  0x0 0x00001000>;
 		reg-names = "cfg";

--- a/arch/riscv/boot/dts/sophgo/mango-sophgo-pisces.dts
+++ b/arch/riscv/boot/dts/sophgo/mango-sophgo-pisces.dts
@@ -1,4 +1,5 @@
 #include "mango-2sockets.dtsi"
+#include "mango-top-intc2.dtsi"
 #include "mango-pcie-2rc.dtsi"
 
 / {

--- a/arch/riscv/boot/dts/sophgo/mango-top-intc2.dtsi
+++ b/arch/riscv/boot/dts/sophgo/mango-top-intc2.dtsi
@@ -1,0 +1,62 @@
+#include <dt-bindings/interrupt-controller/irq.h>
+
+#define SOC_PERIPHERAL_IRQ(nr)	(nr)
+
+/ {
+	intc2: top_intc@f030010300 {
+		compatible = "sophgo,top-intc";
+		reg = <0xf0 0x300102E0 0x0 0x4>,
+		      <0xf0 0x30010300 0x0 0x4>,
+		      <0xf0 0x30010304 0x0 0x4>;
+		reg-names = "sta", "set", "clr";
+		reg-bitwidth = <32>;
+		top-intc-id = <1>;
+		interrupt-controller;
+		#interrupt-cells = <0x1>; // only applies to child node
+		for-msi;
+
+		interrupt-parent = <&intc>;
+		interrupts = <SOC_PERIPHERAL_IRQ(288) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(289) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(290) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(291) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(292) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(293) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(294) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(295) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(296) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(297) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(298) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(299) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(300) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(301) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(302) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(303) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(304) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(305) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(306) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(307) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(308) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(309) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(310) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(311) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(312) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(313) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(314) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(315) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(316) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(317) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(318) IRQ_TYPE_LEVEL_HIGH>,
+			     <SOC_PERIPHERAL_IRQ(319) IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-names = "msi0",  "msi1",  "msi2",  "msi3",
+				  "msi4",  "msi5",  "msi6",  "msi7",
+				  "msi8",  "msi9",  "msi10", "msi11",
+				  "msi12", "msi13", "msi14", "msi15",
+				  "msi16", "msi17", "msi18", "msi19",
+				  "msi20", "msi21", "msi22", "msi23",
+				  "msi24", "msi25", "msi26", "msi27",
+				  "msi28", "msi29", "msi30", "msi31";
+
+	};
+
+};

--- a/arch/riscv/boot/dts/sophgo/mango.dtsi
+++ b/arch/riscv/boot/dts/sophgo/mango.dtsi
@@ -790,13 +790,14 @@
 		};
 	};
 
-	intc1: top_intc {
+	intc1: top_intc@7030010300 {
 		compatible = "sophgo,top-intc";
 		reg = <0x70 0x300102E0 0x0 0x4>,
 		      <0x70 0x30010300 0x0 0x4>,
 		      <0x70 0x30010304 0x0 0x4>;
 		reg-names = "sta", "set", "clr";
 		reg-bitwidth = <32>;
+		top_intc_id = <0>;
 		interrupt-controller;
 		#interrupt-cells = <0x1>; // only applies to child node
 		for-msi;

--- a/drivers/pci/controller/cadence/pcie-cadence-sophgo.h
+++ b/drivers/pci/controller/cadence/pcie-cadence-sophgo.h
@@ -1,6 +1,6 @@
 #ifndef PCIE_CADENCE_SOPHGO
 #define PCIE_CADENCE_SOPHGO
 
-extern struct irq_domain *cdns_pcie_get_parent_irq_domain(void);
+extern struct irq_domain *cdns_pcie_get_parent_irq_domain(int intc_id);
 
 #endif


### PR DESCRIPTION
driver:pcie: enable top intc of chip1 for server