### PR TITLE
riscv: sophgo: change PMU definition

### DIFF
--- a/arch/riscv/boot/dts/sophgo/mango.dtsi
+++ b/arch/riscv/boot/dts/sophgo/mango.dtsi
@@ -63,75 +63,112 @@
 
 	pmu {
 		compatible = "riscv,pmu";
-		riscv,event-to-mhpmevent = /* SBI_PMU_HW_BRANCH_MISSES -> mhpmevent10 */
-					   <0x00006 0x00000000 0x00000008>,
-					   /* SBI_PMU_HW_BRANCH_INSTRUCTIONS -> mhpmevent11 */
-					   <0x00005 0x00000000 0x00000009>,
-					   /* L1I_READ_ACCESS -> mhpmevent3 */
-					   <0x10008 0x00000000 0x00000001>,
-					   /* L1I_READ_MISS -> mhpmevent4 */
-					   <0x10009 0x00000000 0x00000002>,
-					   /* ITLB_READ_MISS -> mhpmevent5 */
-					   <0x10021 0x00000000 0x00000003>,
-					   /* DTLB_READ_MISS -> mhpmevent6 */
-					   <0x10019 0x00000000 0x00000004>,
-					   /* L1D_READ_ACCESS -> mhpmevent14 */
-					   <0x10000 0x00000000 0x0000000c>,
-					   /* L1D_READ_MISS -> mhpmevent15 */
-					   <0x10001 0x00000000 0x0000000d>,
-					   /* L1D_WRITE_ACCESS -> mhpmevent16 */
-					   <0x10002 0x00000000 0x0000000e>,
-					   /* L1D_WRITE_MISS -> mhpmevent17 */
-					   <0x10003 0x00000000 0x0000000f>,
-					   /* LL_READ_ACCESS -> mhpmevent18 */
-					   <0x10010 0x00000000 0x00000010>,
-					   /* LL_READ_MISS -> mhpmevent19 */
-					   <0x10011 0x00000000 0x00000011>,
-					   /* LL_WRITE_ACCESS -> mhpmevent20 */
-					   <0x10012 0x00000000 0x00000012>,
-					   /* LL_WRITE_MISS -> mhpmevent21 */
-					   <0x10013 0x00000000 0x00000013>;
-		riscv,event-to-mhpmcounters = <0x00006 0x00006 0x00000400>,
-					      <0x00005 0x00005 0x00000800>,
-					      <0x10000 0x10000 0x00004000>,
-					      <0x10001 0x10001 0x00008000>,
-					      <0x10002 0x10002 0x00010000>,
-					      <0x10003 0x10003 0x00020000>,
-					      <0x10008 0x10008 0x00000008>,
-					      <0x10009 0x10009 0x00000010>,
-					      <0x10010 0x10010 0x00040000>,
-					      <0x10011 0x10011 0x00080000>,
-					      <0x10012 0x10012 0x00100000>,
-					      <0x10013 0x10013 0x00200000>,
-					      <0x10019 0x10019 0x00000040>,
-					      <0x10021 0x10021 0x00000020>;
+		riscv,event-to-mhpmcounters =
+			/* event-start event-end a bitmap of all the MHPMCOUNTERx */
+			<0x00003 0x00003 0x00000008>,
+			<0x00004 0x00004 0x00000010>,
+			<0x00005 0x00005 0x00000200>,
+			<0x00006 0x00006 0x00000100>,
+			<0x00007 0x00007 0x00000400>,
+			<0x00008 0x00008 0x00000800>,
+			<0x00009 0x00009 0x00001000>,
+			<0x0000a 0x0000a 0x00002000>,
+			<0x10000 0x10000 0x00004000>,
+			<0x10001 0x10001 0x00008000>,
+			<0x10002 0x10002 0x00010000>,
+			<0x10003 0x10003 0x00020000>,
+			<0x10010 0x10010 0x00040000>,
+			<0x10011 0x10011 0x00080000>,
+			<0x10012 0x10012 0x00100000>,
+			<0x10013 0x10013 0x00200000>;
+		riscv,event-to-mhpmevent =
+			/* event-id event-selector */
+			/* mhpmevent3: PMU_HW_CACHE_REFERENCES */
+			<0x00003 0x00000000 0x00000001>,
+			/* mhpmevent4: PMU_HW_CACHE_MISSES */
+			<0x00004 0x00000000 0x00000002>,
+			/* mhpmevent8: PMU_HW_BRANCH_MISSES */
+			<0x00006 0x00000000 0x00000006>,
+			/* mhpmevent9: PMU_HW_BRANCH_INSTRUCTIONS */
+			<0x00005 0x00000000 0x00000007>,
+			/* mhpmevent10: PMU_HW_BUS_CYCLES */
+			<0x00007 0x00000000 0x00000008>,
+			/* mhpmevent11: PMU_HW_STALLED_CYCLES_FRONTEND */
+			<0x00008 0x00000000 0x00000009>,
+			/* mhpmevent12: PMU_HW_STALLED_CYCLES_BACKEND */
+			<0x00009 0x00000000 0x0000000a>,
+			/* mhpmevent13: PMU_HW_REF_CPU_CYCLES */
+			<0x0000a 0x00000000 0x0000000b>,
+			/* mhpmevent14: L1D_READ_ACCESS */
+			<0x10000 0x00000000 0x0000000c>,
+			/* mhpmevent15: L1D_READ_MISS */
+			<0x10001 0x00000000 0x0000000d>,
+			/* mhpmevent16: L1D_WRITE_ACCESS */
+			<0x10002 0x00000000 0x0000000e>,
+			/* mhpmevent17: L1D_WRITE_MISS */
+			<0x10003 0x00000000 0x0000000f>,
+			/* mhpmevent18: LL_READ_ACCESS */
+			<0x10010 0x00000000 0x00000010>,
+			/* mhpmevent19: LL_READ_MISS */
+			<0x10011 0x00000000 0x00000011>,
+			/* mhpmevent20: LL_WRITE_ACCESS */
+			<0x10012 0x00000000 0x00000012>,
+			/* mhpmevent21: LL_WRITE_MISS */
+			<0x10013 0x00000000 0x00000013>;
 		riscv,raw-event-to-mhpmcounters =
-			    /* the platform encodes each raw PMU event as a unique ID,
-			     * the value of variant must be 0xffffffff_ffffffff */
-			    // /* JTLB Miss -> mhpmevent7: jTLB only in T-HEAD */
-			    // <0x00000000 0x00000005 0xffffffff 0xffffffff 0x00000080>,
-				/* Conditional Branch Mispredict -> mhpmevent8 */
-				<0x00000000 0x00000006 0xffffffff 0xffffffff 0x00000100>,
-				/* LSU Spec Fail -> mhpmevent12 */
-				<0x00000000 0x0000000a 0xffffffff 0xffffffff 0x00001000>,
-				/* Store Instruction -> mhpmevent13 */
-				<0x00000000 0x0000000b 0xffffffff 0xffffffff 0x00002000>,
-				/* RF Launch Fail -> mhpmevent22 */
-				<0x00000000 0x00000014 0xffffffff 0xffffffff 0x00400000>,
-				/* RF Reg Launch Fail -> mhpmevent23 */
-				<0x00000000 0x00000015 0xffffffff 0xffffffff 0x00800000>,
-				/* RF Instruction -> mhpmevent24 */
-				<0x00000000 0x00000016 0xffffffff 0xffffffff 0x01000000>,
-				/* LSU Cross 4K Stall -> mhpmevent25 */
-				<0x00000000 0x00000017 0xffffffff 0xffffffff 0x02000000>,
-				/* LSU Other Stall -> mhpmevent26 */
-				<0x00000000 0x00000018 0xffffffff 0xffffffff 0x04000000>,
-				/* LSU SQ Discard -> mhpmevent27 */
-				<0x00000000 0x00000019 0xffffffff 0xffffffff 0x08000000>,
-				/* LSU SQ Data Discard -> mhpmevent28 */
-				<0x00000000 0x0000001a 0xffffffff 0xffffffff 0x10000000>;
+			/* mhpmevent3: L1 ICache Access Counter */
+			<0x00000000 0x00000001 0xffffffff 0xffffffff 0x00000008>,
+			/* mhpmevent4: L1 ICache Miss Counter */
+			<0x00000000 0x00000002 0xffffffff 0xffffffff 0x00000010>,
+			/* mhpmevent5: I-UTLB Miss Counter */
+			<0x00000000 0x00000003 0xffffffff 0xffffffff 0x00000020>,
+			/* mhpmevent6: D-UTLB Miss Counter */
+			<0x00000000 0x00000004 0xffffffff 0xffffffff 0x00000040>,
+			/* mhpmevent7: JTLB Miss */
+			<0x00000000 0x00000005 0xffffffff 0xffffffff 0x00000080>,
+			/* mhpmevent8: Mispredicted branch instructions */
+			<0x00000000 0x00000006 0xffffffff 0xffffffff 0x00000100>,
+			/* mhpmevent9: Retired branch instructions */
+			<0x00000000 0x00000007 0xffffffff 0xffffffff 0x00000200>,
+			/* mhpmevent10: Bus Cycles */
+			<0x00000000 0x00000008 0xffffffff 0xffffffff 0x00000400>,
+			/* mhpmevent11: Issue stalled cycles */
+			<0x00000000 0x00000009 0xffffffff 0xffffffff 0x00000800>,
+			/* mhpmevent12: Retirement Stalled cycles */
+			<0x00000000 0x0000000a 0xffffffff 0xffffffff 0x00001000>,
+			/* mhpmevent13: Total cycles (not affected by CPU frequency scaling) */
+			<0x00000000 0x0000000b 0xffffffff 0xffffffff 0x00002000>,
+			/* mhpmevent14: L1 DCache read access Counter */
+			<0x00000000 0x0000000c 0xffffffff 0xffffffff 0x00004000>,
+			/* mhpmevent15: L1 DCache read miss Counter */
+			<0x00000000 0x0000000d 0xffffffff 0xffffffff 0x00008000>,
+			/* mhpmevent16: L1 DCache write access Counter */
+			<0x00000000 0x0000000e 0xffffffff 0xffffffff 0x00010000>,
+			/* mhpmevent17: L1 DCache write access Counter */
+			<0x00000000 0x0000000f 0xffffffff 0xffffffff 0x00020000>,
+			/* mhpmevent18: L2 Cache read access Counter */
+			<0x00000000 0x00000010 0xffffffff 0xffffffff 0x00040000>,
+			/* mhpmevent19: L2 Cache read miss Counter */
+			<0x00000000 0x00000011 0xffffffff 0xffffffff 0x00080000>,
+			/* mhpmevent20: L2 Cache write access Counter */
+			<0x00000000 0x00000012 0xffffffff 0xffffffff 0x00100000>,
+			/* mhpmevent21: L2 Cache write miss Counter */
+			<0x00000000 0x00000013 0xffffffff 0xffffffff 0x00200000>,
+			/* mhpmevent22: RF Launch Fail */
+			<0x00000000 0x00000014 0xffffffff 0xffffffff 0x00400000>,
+			/* mhpmevent23: RF Reg Launch Fail */
+			<0x00000000 0x00000015 0xffffffff 0xffffffff 0x00800000>,
+			/* mhpmevent24: RF Instruction */
+			<0x00000000 0x00000016 0xffffffff 0xffffffff 0x01000000>,
+			/* mhpmevent25: LSU Cross 4K Stall */
+			<0x00000000 0x00000017 0xffffffff 0xffffffff 0x02000000>,
+			/* mhpmevent26: LSU Other Stall */
+			<0x00000000 0x00000018 0xffffffff 0xffffffff 0x04000000>,
+			/* mhpmevent27: LSU SQ Discard */
+			<0x00000000 0x00000019 0xffffffff 0xffffffff 0x08000000>,
+			/* mhpmevent28: LSU SQ Data Discard */
+			<0x00000000 0x0000001a 0xffffffff 0xffffffff 0x10000000>;
 	};
-
 	soc: soc {
 		#address-cells = <2>;
 		#size-cells = <2>;


### PR DESCRIPTION
As the PMU events described in T-HEAD document have some mistake. Fix this events with information from T-HEAD vendor kernel driver.