### PR TITLE
riscv:dts: split socket0 pcie1 into double x8 mode for pisces

### DIFF
--- a/arch/riscv/boot/dts/sophgo/mango-pcie-2rc.dtsi
+++ b/arch/riscv/boot/dts/sophgo/mango-pcie-2rc.dtsi
@@ -9,7 +9,7 @@
 		#address-cells = <3>;
 		#size-cells = <2>;
 
-		bus-range = <0x00 0x7f>;
+		bus-range = <0x00 0x3f>;
 		linux,pci-domain = <0>;
 		cdns,max-outbound-regions = <16>;
 		cdns,no-bar-match-nbits = <48>;
@@ -32,11 +32,49 @@
 		// 32bit non-prefetchable memory
 		// 64bit prefetchable memory
 		// 64bit non-prefetchable memory
-		ranges = <0x01000000 0x0  0x00000000  0x48 0x10000000  0x0 0x00800000>,
+		ranges = <0x01000000 0x0  0x00000000  0x48 0x10000000  0x0 0x00400000>,
 			 <0x42000000 0x0  0x20000000  0x48 0x20000000  0x0 0x50000000>,
 			 <0x02000000 0x0  0x70000000  0x48 0x70000000  0x0 0x20000000>,
 			 <0x43000000 0x49 0x00000000  0x49 0x00000000  0x2 0x00000000>,
 			 <0x03000000 0x4b 0x00000000  0x4b 0x00000000  0x1 0x00000000>;
+		dma-ranges = <0x03000000 0x0 0x0 0x0 0x0 0x1f 0x0>;
+
+		status = "okay";
+	};
+
+	pcie@7062800000 {
+		compatible = "sophgo,cdns-pcie-host";
+		device_type = "pci";
+		#address-cells = <3>;
+		#size-cells = <2>;
+
+		bus-range = <0x40 0x7f>;
+		linux,pci-domain = <1>;
+		cdns,max-outbound-regions = <16>;
+		cdns,no-bar-match-nbits = <48>;
+		vendor-id = /bits/ 16 <0x1E30>;
+		device-id = /bits/ 16 <0x2042>;
+		pcie-id = /bits/ 16 <0x1>;
+		link-id = /bits/ 16 <0x1>;
+		top-intc-used = <1>;
+		top-intc-id = <0>;
+		msix-supported = <0>;
+		interrupt-parent = <&intc1>;
+		//interrupts = <SOC_PERIPHERAL_IRQ(123) IRQ_TYPE_LEVEL_HIGH>;
+		//interrupt-names = "msi";
+		reg = <0x4c 0x00000000  0x0 0x00001000>;
+		reg-names = "cfg";
+
+		// IO, check IO_SPACE_LIMIT
+		// 32bit prefetchable memory
+		// 32bit non-prefetchable memory
+		// 64bit prefetchable memory
+		// 64bit non-prefetchable memory
+		ranges = <0x01000000 0x0  0x00000000  0x4c 0x10400000  0x0 0x00400000>,
+			 <0x42000000 0x0  0x20000000  0x4c 0x20000000  0x0 0x50000000>,
+			 <0x02000000 0x0  0x70000000  0x4c 0x70000000  0x0 0x20000000>,
+			 <0x43000000 0x4d 0x00000000  0x4d 0x00000000  0x2 0x00000000>,
+			 <0x03000000 0x4f 0x00000000  0x4f 0x00000000  0x1 0x00000000>;
 		dma-ranges = <0x03000000 0x0 0x0 0x0 0x0 0x1f 0x0>;
 
 		status = "okay";
@@ -49,7 +87,7 @@
 		#size-cells = <2>;
 
 		bus-range = <0x80 0xff>;
-		linux,pci-domain = <1>;
+		linux,pci-domain = <2>;
 		cdns,max-outbound-regions = <16>;
 		cdns,no-bar-match-nbits = <48>;
 		vendor-id = /bits/ 16 <0x1E30>;


### PR DESCRIPTION
This is a workround for the PMC switch hang when to access device linked to its DSP