### PR TITLE
drivers: pcie: Add switchtec to the PCIE MSIX whitelist

### DIFF
--- a/arch/riscv/boot/dts/sophgo/mango-pcie-2rc.dtsi
+++ b/arch/riscv/boot/dts/sophgo/mango-pcie-2rc.dtsi
@@ -58,7 +58,7 @@
 		link-id = /bits/ 16 <0x0>;
 		top-intc-used = <1>;
 		top-intc-id = <1>;
-		msix-supported = <0>;
+		msix-supported = <1>;
 		interrupt-parent = <&intc2>;
 		//interrupts = <SOC_PERIPHERAL_IRQ(346) IRQ_TYPE_LEVEL_HIGH>;
 		//interrupt-names = "msi";

--- a/drivers/pci/controller/cadence/pcie-cadence-sophgo.c
+++ b/drivers/pci/controller/cadence/pcie-cadence-sophgo.c
@@ -463,6 +463,7 @@ static struct msi_domain_info cdns_pcie_top_intr_msi_domain_info = {
 struct vendor_id_list vendor_id_list[] = {
 	{"Inter X520", 0x8086},
 	{"WangXun RP1000", 0x8088},
+	{"Switchtec", 0x11f8},
 };
 
 size_t vendor_id_list_num = ARRAY_SIZE(vendor_id_list);


### PR DESCRIPTION
riscv: dts: sophgo: Set PCIE1 to support msix