### PR TITLE
perf cpumap: Make counter as unsigned ints

### DIFF
--- a/tools/lib/perf/cpumap.c
+++ b/tools/lib/perf/cpumap.c
@@ -351,8 +351,8 @@ struct perf_cpu_map *perf_cpu_map__merge(struct perf_cpu_map *orig,
 					 struct perf_cpu_map *other)
 {
 	struct perf_cpu *tmp_cpus;
-	int tmp_len;
-	int i, j, k;
+	unsigned int tmp_len;
+	unsigned int i, j, k;
 	struct perf_cpu_map *merged;
 
 	if (perf_cpu_map__is_subset(orig, other))
@@ -369,7 +369,7 @@ struct perf_cpu_map *perf_cpu_map__merge(struct perf_cpu_map *orig,
 
 	/* Standard merge algorithm from wikipedia */
 	i = j = k = 0;
-	while (i < orig->nr && j < other->nr) {
+	while (i < (unsigned int)orig->nr && j < (unsigned int)other->nr) {
 		if (orig->map[i].cpu <= other->map[j].cpu) {
 			if (orig->map[i].cpu == other->map[j].cpu)
 				j++;
@@ -378,10 +378,10 @@ struct perf_cpu_map *perf_cpu_map__merge(struct perf_cpu_map *orig,
 			tmp_cpus[k++] = other->map[j++];
 	}
 
-	while (i < orig->nr)
+	while (i < (unsigned int)orig->nr)
 		tmp_cpus[k++] = orig->map[i++];
 
-	while (j < other->nr)
+	while (j < (unsigned int)other->nr)
 		tmp_cpus[k++] = other->map[j++];
 	assert(k <= tmp_len);
 


### PR DESCRIPTION
These are loop counters which is inherently unsigned. Therefore make them unsigned. Moreover it also fixes alloc-size-larger-than error with gcc-13, where malloc can be called with (-1) due to tmp_len being an int type.

Fixes
| cpumap.c:366:20: error: argument 1 range [18446744065119617024, 18446744073709551612] exceeds maximum object size 9223372036854775807 [-Werror=alloc-size-larger-than=]
|   366 |         tmp_cpus = malloc(tmp_len * sizeof(struct perf_cpu));
|       |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

refer: https://www.spinics.net/lists/linux-perf-users/msg25755.html
patch: https://git.yoctoproject.org/poky/plain/meta/recipes-kernel/linux/files/0001-perf-cpumap-Make-counter-as-unsigned-ints.patch