### PR TITLE
kernel: tick: filter unnecessary printing

### DIFF
--- a/kernel/time/tick-oneshot.c
+++ b/kernel/time/tick-oneshot.c
@@ -78,7 +78,7 @@ int tick_switch_to_oneshot(void (*handler)(struct clock_event_device *))
 	if (!dev || !(dev->features & CLOCK_EVT_FEAT_ONESHOT) ||
 		    !tick_device_is_functional(dev)) {
 
-		pr_warn("Clockevents: could not switch to one-shot mode:");
+		pr_debug("Clockevents: could not switch to one-shot mode:");
 		if (!dev) {
 			pr_cont(" no tick device\n");
 		} else {


### PR DESCRIPTION
set the print level of the switch_to oneshot function to DEBUG