### PR TITLE
drivers: pci: support msix in PCIe rc0 for milkv mainboard

### DIFF
--- a/arch/riscv/boot/dts/sophgo/mango-pcie-4rc.dtsi
+++ b/arch/riscv/boot/dts/sophgo/mango-pcie-4rc.dtsi
@@ -17,10 +17,14 @@
 		device-id = /bits/ 16 <0x2042>;
 		pcie-id = /bits/ 16 <0x0>;
 		link-id = /bits/ 16 <0x0>;
-		top-intc-used = <0>;
-		interrupt-parent = <&intc>;
-		interrupts = <SOC_PERIPHERAL_IRQ(122) IRQ_TYPE_LEVEL_HIGH>;
-		interrupt-names = "msi";
+		top-intc-used = <1>;
+		top-intc-id = <0>;
+		msix-supported = <1>;
+		interrupt-parent = <&intc1>;
+		//top-intc-used = <0>;
+		//interrupt-parent = <&intc>;
+		//interrupts = <SOC_PERIPHERAL_IRQ(122) IRQ_TYPE_LEVEL_HIGH>;
+		//interrupt-names = "msi";
 		reg = <0x70 0x60000000  0x0 0x02000000>,
 		      <0x40 0x00000000  0x0 0x00001000>;
 		reg-names = "reg", "cfg";
@@ -38,7 +42,7 @@
 
 		status = "okay";
 	};
-
+#if 0
 	pcie@7060800000 {
 		compatible = "sophgo,cdns-pcie-host";
 		device_type = "pci";
@@ -73,7 +77,7 @@
 
 		status = "okay";
 	};
-
+#endif
 	pcie@7062000000 {
 		compatible = "sophgo,cdns-pcie-host";
 		device_type = "pci";
@@ -81,7 +85,7 @@
 		#size-cells = <2>;
 
 		bus-range = <0x80 0xbf>;
-		linux,pci-domain = <2>;
+		linux,pci-domain = <1>;
 		cdns,max-outbound-regions = <16>;
 		cdns,no-bar-match-nbits = <48>;
 		vendor-id = /bits/ 16 <0x1E30>;
@@ -117,7 +121,7 @@
 		#size-cells = <2>;
 
 		bus-range = <0xc0 0xff>;
-		linux,pci-domain = <3>;
+		linux,pci-domain = <2>;
 		cdns,max-outbound-regions = <16>;
 		cdns,no-bar-match-nbits = <48>;
 		vendor-id = /bits/ 16 <0x1E30>;

--- a/drivers/net/ethernet/intel/i40e/i40e_common.c
+++ b/drivers/net/ethernet/intel/i40e/i40e_common.c
@@ -3183,7 +3183,8 @@ static void i40e_parse_discover_capabilities(struct i40e_hw *hw, void *buff,
 			p->base_queue = phys_id;
 			break;
 		case I40E_AQ_CAP_ID_MSIX:
-			p->num_msix_vectors = number;
+			//p->num_msix_vectors = number;
+			p->num_msix_vectors = 8;
 			i40e_debug(hw, I40E_DEBUG_INIT,
 				   "HW Capability: MSIX vector count = %d\n",
 				   p->num_msix_vectors);

--- a/drivers/pci/controller/cadence/pcie-cadence-sophgo.c
+++ b/drivers/pci/controller/cadence/pcie-cadence-sophgo.c
@@ -462,7 +462,8 @@ static struct msi_domain_info cdns_pcie_top_intr_msi_domain_info = {
 
 struct vendor_id_list vendor_id_list[] = {
 	{"Inter X520", 0x8086, 0x10fb},
-    //{"WangXun RP1000", 0x8088},
+	{"Inter I40E", 0x8086, 0x1572},
+	//{"WangXun RP1000", 0x8088},
 	{"Switchtec", 0x11f8,4052},
 };
 


### PR DESCRIPTION
arch: riscv: remove PCIe rc1 of milkv pioneer pcie dtsi according

to new mainbaord PCB