### PR TITLE
riscv: kexec: Gate kexec image loader with CONFIG_CRASH_DUMP

### DIFF
--- a/arch/riscv/kernel/image_kexec.c
+++ b/arch/riscv/kernel/image_kexec.c
@@ -24,6 +24,8 @@
 #include <asm/byteorder.h>
 #include <asm/image.h>
 
+#ifdef CONFIG_CRASH_DUMP
+
 static int prepare_elf_headers(void **addr, unsigned long *sz)
 {
 	struct crash_mem *cmem;
@@ -303,3 +305,5 @@ const struct kexec_file_ops image_kexec_ops = {
 	.verify_sig = image_verify_sig,
 #endif
 };
+
+#endif


### PR DESCRIPTION
This commit fixes the kernel build when `CONFIG_CRASH_DUMP` is not enabled.
/cc @xingxg2022 