### PR TITLE
pcie: whitelist and support mellanox connectx-2

### DIFF
--- a/drivers/pci/controller/cadence/pcie-cadence-sophgo.c
+++ b/drivers/pci/controller/cadence/pcie-cadence-sophgo.c
@@ -465,6 +465,7 @@ struct vendor_id_list vendor_id_list[] = {
 	{"Inter I40E", 0x8086, 0x1572},
 	//{"WangXun RP1000", 0x8088},
 	{"Switchtec", 0x11f8,0x4052},
+	{"Mellanox ConnectX-2", 0x15b3, 0x6750}
 };
 
 size_t vendor_id_list_num = ARRAY_SIZE(vendor_id_list);

--- a/include/linux/mlx4/device.h
+++ b/include/linux/mlx4/device.h
@@ -46,7 +46,7 @@
 
 #define DEFAULT_UAR_PAGE_SHIFT  12
 
-#define MAX_MSIX		128
+#define MAX_MSIX		16
 #define MIN_MSIX_P_PORT		5
 #define MLX4_IS_LEGACY_EQ_MODE(dev_cap) ((dev_cap).num_comp_vectors < \
 					 (dev_cap).num_ports * MIN_MSIX_P_PORT)


### PR DESCRIPTION
Basic functionalities have been tested to work fine on pioneer board.