### PR TITLE
Revert "sched: Remove sched_setscheduler*() EXPORTs"

### DIFF
--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -7885,11 +7885,13 @@ int sched_setscheduler(struct task_struct *p, int policy,
 {
 	return _sched_setscheduler(p, policy, param, true);
 }
+EXPORT_SYMBOL_GPL(sched_setscheduler);
 
 int sched_setattr(struct task_struct *p, const struct sched_attr *attr)
 {
 	return __sched_setscheduler(p, attr, true, true);
 }
+EXPORT_SYMBOL_GPL(sched_setattr);
 
 int sched_setattr_nocheck(struct task_struct *p, const struct sched_attr *attr)
 {
@@ -7915,6 +7917,7 @@ int sched_setscheduler_nocheck(struct task_struct *p, int policy,
 {
 	return _sched_setscheduler(p, policy, param, false);
 }
+EXPORT_SYMBOL_GPL(sched_setscheduler_nocheck);
 
 /*
  * SCHED_FIFO is a broken scheduler model; that is, it is fundamentally


### PR DESCRIPTION
Reason:The SG2260 multimedia module requires the thread priority setting function

This reverts commit 616d91b68cd56bcb1954b6a5af7d542401fde772.