### PR TITLE
riscv:dts 2044 bringup set default uart config.

### DIFF
--- a/arch/riscv/boot/dts/sophgo/sg2260-ap-pld.dts
+++ b/arch/riscv/boot/dts/sophgo/sg2260-ap-pld.dts
@@ -133,7 +133,7 @@
 			riscv,max-priority = <7>;
 			riscv,ndev = <415>;
 		};
-
+#if 0
 		dummy_apb: apb-clock {
 			compatible = "fixed-clock";
 			clock-frequency = <250000000>;
@@ -154,18 +154,21 @@
 			clock-output-names = "dummy_axi";
 			#clock-cells = <0>;
 		};
-
+#endif
 		uart0: serial@7030000000 {
 			compatible = "snps,dw-apb-uart";
 			reg = <0x00000070 0x30000000 0x00000000 0x00001000>;
 			interrupt-parent = <&intc>;
 			interrupts = <41 IRQ_TYPE_LEVEL_HIGH>;
-			clock-frequency = <153600>;
-			clock-names = "baudclk";
+			clock-frequency = <500000000>;
+			clocks = <&div_clk GATE_CLK_UART_500M>,
+					 <&div_clk GATE_CLK_APB_UART>;
+			clock-names = "baudclk", "apb_pclk";
+			current-speed = <115200>;
 			reg-shift = <2>;
 			reg-io-width = <4>;
 		};
-
+#if 0
 		gpio0: gpio@7040009000 {
 			compatible = "snps,dw-apb-gpio";
 			reg = <0x70 0x40009000 0x0 0x400>;
@@ -254,7 +257,6 @@
 			interrupt-names = "CXP_CDMA0";
 		};
 
-#if 0
 		stmmac_axi_setup: stmmac-axi-config {
 			snps,wr_osr_lmt = <1>;
 			snps,rd_osr_lmt = <2>;
@@ -396,7 +398,7 @@
 	};
 
 	chosen {
-		bootargs = "console=ttyS0,9600 earlycon rdinit=/init root=/dev/ram0 rw initrd=0x8b000000,32M rdmem=0x100000000,2040M maxcpus=4 no5lvl";
+		bootargs = "console=ttyS0,115200 earlycon rdinit=/init root=/dev/ram0 rw initrd=0x8b000000,32M rdmem=0x100000000,2040M maxcpus=4 no5lvl";
 		stdout-path = "serial0";
 	};
 

--- a/arch/riscv/boot/dts/sophgo/sg2260-rp-pld.dts
+++ b/arch/riscv/boot/dts/sophgo/sg2260-rp-pld.dts
@@ -5,6 +5,10 @@
 
 /dts-v1/;
 #include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/clock/sophgo,sg2044-clock.h>
+#include <dt-bindings/reset/sophgo,sg2044-reset.h>
+#include "sg2044-clock.dtsi"
+#include "sg2044-pinctrl.dtsi"
 
 / {
 	model = "sophgo sg2260";
@@ -1318,8 +1322,11 @@
 			reg = <0x00000070 0x30001000 0x00000000 0x00001000>;
 			interrupt-parent = <&intc>;
 			interrupts = <42 IRQ_TYPE_LEVEL_HIGH>;
-			clock-frequency = <153600>;
-			clock-names = "baudclk";
+			clock-frequency = <500000000>;
+			clocks = <&div_clk GATE_CLK_UART_500M>,
+					 <&div_clk GATE_CLK_APB_UART>;
+			clock-names = "baudclk", "apb_pclk";
+			current-speed = <115200>;
 			reg-shift = <2>;
 			reg-io-width = <4>;
 		};
@@ -1341,7 +1348,20 @@
 	};
 
 	chosen {
-		bootargs = "console=ttyS0,9600 earlycon rdinit=/init root=/dev/ram0 rw initrd=0x8b000000,32M rdmem=0x100000000,4096M no5lvl";
+		bootargs = "console=ttyS0,115200 earlycon rdinit=/init root=/dev/ram0 rw initrd=0x8b000000,32M rdmem=0x100000000,4096M no5lvl";
 		stdout-path = "serial0";
+	};
+
+	top_misc: top_misc_ctrl@7050000000 {
+		compatible = "syscon";
+		reg = <0x70 0x50000000 0x0 0x8000>;
+	};
+
+	rst: reset-controller {
+		#reset-cells = <1>;
+		compatible = "sophgo,reset";
+		subctrl-syscon = <&top_misc>;
+		top_rst_offset = <0x3000>;
+		nr_resets = <RST_MAX_NUM>;
 	};
 };

--- a/arch/riscv/boot/dts/sophgo/sg2260-tp-pld.dts
+++ b/arch/riscv/boot/dts/sophgo/sg2260-tp-pld.dts
@@ -1,4 +1,14 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Copyright (C) 2022 Sophgo Technology Inc. All rights reserved.
+ */
+
 /dts-v1/;
+#include <dt-bindings/reset/sophgo,sg2044-reset.h>
+#include <dt-bindings/clock/sophgo,sg2044-clock.h>
+#include "sg2044-clock.dtsi"
+#include "sg2044-pinctrl.dtsi"
+
 / {
 	model = "sophgo sg2260";
 	compatible = "sophgo, sg2260_pld";
@@ -75,8 +85,11 @@
 			reg = <0x00000070 0x30000000 0x00000000 0x00001000>;
 			interrupt-parent = <&intc>;
 			interrupts = <73>;
-			clock-frequency = <153600>;
-			clock-names = "baudclk";
+			clock-frequency = <500000000>;
+			clocks = <&div_clk GATE_CLK_UART_500M>,
+					 <&div_clk GATE_CLK_APB_UART>;
+			clock-names = "baudclk", "apb_pclk";
+			current-speed = <115200>;
 			reg-shift = <2>;
 			reg-io-width = <4>;
 		};
@@ -98,7 +111,20 @@
 	};
 
 	chosen {
-		bootargs = "console=ttyS0,9600 earlycon rdinit=/init root=/dev/ram0 rw initrd=0x30000000,32M rdmem=0x80000000,2040M no5lvl";
+		bootargs = "console=ttyS0,115200 earlycon rdinit=/init root=/dev/ram0 rw initrd=0x30000000,32M rdmem=0x80000000,2040M no5lvl";
 		stdout-path = "serial0";
+	};
+
+	top_misc: top_misc_ctrl@7050000000 {
+		compatible = "syscon";
+		reg = <0x70 0x50000000 0x0 0x8000>;
+	};
+
+	rst: reset-controller {
+		#reset-cells = <1>;
+		compatible = "sophgo,reset";
+		subctrl-syscon = <&top_misc>;
+		top_rst_offset = <0x3000>;
+		nr_resets = <RST_MAX_NUM>;
 	};
 };

--- a/drivers/clk/sophgo/clk.c
+++ b/drivers/clk/sophgo/clk.c
@@ -349,7 +349,7 @@ static int __get_pll_ctl_setting(struct sg2044_pll_ctrl *best,
 static unsigned long sg2044_clk_pll_recalc_rate(struct clk_hw *hw,
 					    unsigned long parent_rate)
 {
-	unsigned int value;
+	unsigned int value = 0;
 	unsigned long rate;
 	struct sg2044_pll_clock *sg2044_pll = to_sg2044_pll_clk(hw);
 


### PR DESCRIPTION
1. set uart frequency to 500000000.
2. uart get clk by clk tree.
3. add current-speed node for opensbi and kernel set uart baud.
4. set uart baud 115200 in bootarg.
5. add this modify to rp and tp.
6. fix uninit warning when compile in drivers/clk/sophgo/clk.c.