### PR TITLE
riscv:driver:clk: fix SG2044 clk tree bugs.

### DIFF
--- a/arch/riscv/boot/dts/sophgo/sg2044-clock.dtsi
+++ b/arch/riscv/boot/dts/sophgo/sg2044-clock.dtsi
@@ -190,10 +190,6 @@
 			compatible = "sg2044, clk-default-rates";
 			#clock-cells = <1>;
 			clocks = \
-				<&mpll0>, <&mpll1>, <&mpll2>, <&mpll3>,
-                <&mpll4>, <&mpll5>,
-                <&fpll0>, <&fpll1>,
-
 				<&div_clk DIV_CLK_MPLL0_AP_CPU_NORMAL_0>,
 				<&div_clk DIV_CLK_MPLL1_RP_SYS_0>,
 				<&div_clk DIV_CLK_MPLL2_TPU_SYS_0>,
@@ -236,11 +232,8 @@
 				<&div_clk DIV_CLK_FPLL1_PCIE_1G>;
 
 			clock-rates = \
-				<2000000000>, <2200000000>, <1200000000>, <2000000000>,
-				<1050000000>, <900000000>,
-				<2000000000>, <1000000000>,
 				/* MPLL */
-				<2000000000>, <2200000000>, <1200000000>,
+				<2000000000>, <2200000001>, <1200000000>,
 				<2000000000>, <1050000000>, <900000000>,
 				/* FPLL */
 				<2000000000>, <1200000000>, <2200000000>,

--- a/arch/riscv/boot/dts/sophgo/sg2260-ap-pld.dts
+++ b/arch/riscv/boot/dts/sophgo/sg2260-ap-pld.dts
@@ -19,7 +19,7 @@
 
 	memory@80200000 {
 		device_type = "memory";
-		reg = <0x00000000 0x80200000 0x00000000 0xfe00000>;
+		reg = <0x00000000 0x80200000 0x00000000 0x7fe00000>;
 	};
 
 	cpus {
@@ -88,6 +88,19 @@
 		};
 	};
 
+	top_misc: top_misc_ctrl@7050000000 {
+		compatible = "syscon";
+		reg = <0x70 0x50000000 0x0 0x8000>;
+	};
+
+	rst: reset-controller {
+		#reset-cells = <1>;
+		compatible = "sophgo,reset";
+		subctrl-syscon = <&top_misc>;
+		top_rst_offset = <0x3000>;
+		nr_resets = <RST_MAX_NUM>;
+	};
+
 	soc {
 		#address-cells = <2>;
 		#size-cells = <2>;
@@ -133,28 +146,7 @@
 			riscv,max-priority = <7>;
 			riscv,ndev = <415>;
 		};
-#if 0
-		dummy_apb: apb-clock {
-			compatible = "fixed-clock";
-			clock-frequency = <250000000>;
-			clock-output-names = "dummy_apb";
-			#clock-cells = <0>;
-		};
 
-		dummy_ahb: ahb-clock {
-			compatible = "fixed-clock";
-			clock-frequency = <250000000>;
-			clock-output-names = "dummy_ahb";
-			#clock-cells = <0>;
-		};
-
-		dummy_axi: axi-clock {
-			compatible = "fixed-clock";
-			clock-frequency = <25000000>;
-			clock-output-names = "dummy_axi";
-			#clock-cells = <0>;
-		};
-#endif
 		uart0: serial@7030000000 {
 			compatible = "snps,dw-apb-uart";
 			reg = <0x00000070 0x30000000 0x00000000 0x00001000>;
@@ -483,18 +475,5 @@
 	chosen {
 		bootargs = "console=ttyS0,115200 earlycon rdinit=/init root=/dev/ram0 rw initrd=0x8b000000,32M rdmem=0x100000000,2040M maxcpus=4 no5lvl";
 		stdout-path = "serial0";
-	};
-
-	top_misc: top_misc_ctrl@7050000000 {
-		compatible = "syscon";
-		reg = <0x70 0x50000000 0x0 0x8000>;
-	};
-
-	rst: reset-controller {
-		#reset-cells = <1>;
-		compatible = "sophgo,reset";
-		subctrl-syscon = <&top_misc>;
-		top_rst_offset = <0x3000>;
-		nr_resets = <RST_MAX_NUM>;
 	};
 };

--- a/drivers/clk/sophgo/clk-sg2044.c
+++ b/drivers/clk/sophgo/clk-sg2044.c
@@ -22,6 +22,7 @@ struct sg2044_pll_clock sg2044_root_pll_clks[] = {
 		.flags = CLK_GET_RATE_NOCACHE | CLK_GET_ACCURACY_NOCACHE,
 		.status_offset = 0x98,
 		.enable_offset = 0x9c,
+		.ini_flags = SG2044_CLK_RO,
 	}, {
 		.id = MPLL1_CLK,
 		.name = "mpll1_clock",
@@ -29,6 +30,7 @@ struct sg2044_pll_clock sg2044_root_pll_clks[] = {
 		.flags = CLK_GET_RATE_NOCACHE | CLK_GET_ACCURACY_NOCACHE,
 		.status_offset = 0x98,
 		.enable_offset = 0x9c,
+		.ini_flags = SG2044_CLK_RO,
 	}, {
 		.id = MPLL2_CLK,
 		.name = "mpll2_clock",
@@ -36,6 +38,7 @@ struct sg2044_pll_clock sg2044_root_pll_clks[] = {
 		.flags = CLK_GET_RATE_NOCACHE | CLK_GET_ACCURACY_NOCACHE,
 		.status_offset = 0x98,
 		.enable_offset = 0x9c,
+		.ini_flags = SG2044_CLK_RO,
 	}, {
 		.id = MPLL3_CLK,
 		.name = "mpll3_clock",
@@ -43,6 +46,7 @@ struct sg2044_pll_clock sg2044_root_pll_clks[] = {
 		.flags = CLK_GET_RATE_NOCACHE | CLK_GET_ACCURACY_NOCACHE,
 		.status_offset = 0x98,
 		.enable_offset = 0x9c,
+		.ini_flags = SG2044_CLK_RO,
 	}, {
 		.id = MPLL4_CLK,
 		.name = "mpll4_clock",
@@ -50,6 +54,7 @@ struct sg2044_pll_clock sg2044_root_pll_clks[] = {
 		.flags = CLK_GET_RATE_NOCACHE | CLK_GET_ACCURACY_NOCACHE,
 		.status_offset = 0x98,
 		.enable_offset = 0x9c,
+		.ini_flags = SG2044_CLK_RO,
 	}, {
 		.id = MPLL5_CLK,
 		.name = "mpll5_clock",
@@ -57,6 +62,7 @@ struct sg2044_pll_clock sg2044_root_pll_clks[] = {
 		.flags = CLK_GET_RATE_NOCACHE | CLK_GET_ACCURACY_NOCACHE,
 		.status_offset = 0x98,
 		.enable_offset = 0x9c,
+		.ini_flags = SG2044_CLK_RO,
 	}, {
 		.id = FPLL0_CLK,
 		.name = "fpll0_clock",

--- a/drivers/tty/serial/8250/8250_dw.c
+++ b/drivers/tty/serial/8250/8250_dw.c
@@ -348,7 +348,7 @@ dw8250_do_pm(struct uart_port *port, unsigned int state, unsigned int old)
 	if (state)
 		pm_runtime_put_sync_suspend(port->dev);
 }
-
+#ifndef CONFIG_SOC_SOPHGO
 static void dw8250_set_termios(struct uart_port *p, struct ktermios *termios,
 			       const struct ktermios *old)
 {
@@ -372,7 +372,7 @@ static void dw8250_set_termios(struct uart_port *p, struct ktermios *termios,
 
 	dw8250_do_set_termios(p, termios, old);
 }
-
+#endif
 static void dw8250_set_ldisc(struct uart_port *p, struct ktermios *termios)
 {
 	struct uart_8250_port *up = up_to_u8250p(p);
@@ -539,7 +539,9 @@ static int dw8250_probe(struct platform_device *pdev)
 	p->serial_in	= dw8250_serial_in;
 	p->serial_out	= dw8250_serial_out;
 	p->set_ldisc	= dw8250_set_ldisc;
+	#ifndef CONFIG_SOC_SOPHGO
 	p->set_termios	= dw8250_set_termios;
+	#endif
 
 	p->membase = devm_ioremap(dev, regs->start, resource_size(regs));
 	if (!p->membase)


### PR DESCRIPTION
1. let top_misc before soc node.
2. do not modify pll.
3. uart do not need dw8250_set_termios.