### PR TITLE
riscv:drivers:clk: fix system hang bug in Ubuntu bringup.

### DIFF
--- a/arch/riscv/boot/dts/sophgo/sg2044-clock.dtsi
+++ b/arch/riscv/boot/dts/sophgo/sg2044-clock.dtsi
@@ -195,6 +195,9 @@
 			compatible = "sg2044, clk-default-rates";
 			#clock-cells = <1>;
 			clocks = \
+				<&mpll0>, <&mpll1>, <&mpll2>, <&mpll3>,
+				<&mpll4>, <&mpll5>,
+
 				<&div_clk DIV_CLK_MPLL0_AP_CPU_NORMAL_0>,
 				<&div_clk DIV_CLK_MPLL1_RP_SYS_0>,
 				<&div_clk DIV_CLK_MPLL2_TPU_SYS_0>,
@@ -207,9 +210,7 @@
 				<&div_clk DIV_CLK_FPLL0_AP_CPU_NORMAL_1>,
 				<&div_clk DIV_CLK_FPLL0_SRC0_1>,
 				<&div_clk DIV_CLK_FPLL0_SRC1_1>,
-				<&div_clk DIV_CLK_FPLL0_CXP_TEST_PHY>,
-				<&div_clk DIV_CLK_FPLL0_C2C1_TEST_PHY>,
-				<&div_clk DIV_CLK_FPLL0_C2C0_TEST_PHY>,
+
 				<&div_clk DIV_CLK_FPLL0_TOP_50M>,
 				<&div_clk DIV_CLK_FPLL0_DIV_TMIER1>,
 				<&div_clk DIV_CLK_FPLL0_DIV_TMIER2>,
@@ -237,13 +238,15 @@
 				<&div_clk DIV_CLK_FPLL1_PCIE_1G>;
 
 			clock-rates = \
+				<2000000000>, <2200000000>, <1200000000>, <2000000000>,
+				<1050000000>, <900000000>,
 				/* MPLL */
-				<2000000000>, <2200000001>, <1200000000>,
+				<2000000000>, <2200000000>, <1200000000>,
 				<2000000000>, <1050000000>, <900000000>,
 				/* FPLL */
 				<2000000000>, <1200000000>, <2200000000>,
 				<2000000000>, <1050000000>, <900000000>,
-				<2000000000>, <2000000000>, <2000000000>,
+
 				<50000000>,
 				<50000000>, <50000000>, <50000000>, <50000000>,
 				<50000000>, <50000000>, <50000000>, <50000000>,

--- a/arch/riscv/boot/dts/sophgo/sg2260-peri-sys.dtsi
+++ b/arch/riscv/boot/dts/sophgo/sg2260-peri-sys.dtsi
@@ -447,8 +447,11 @@
 	dwcxlg0: dwcxlg@6c08000000 {
 		compatible = "sophgo,ethernet";
 		reg = <0x6c 0x08000000 0x0 0x40000>;
+		clock-names = "clk_gate_cxp_mac", "clk_gate_cxp_cfg";
+		clocks = <&div_clk GATE_CLK_CXP_MAC>,
+			<&div_clk GATE_CLK_CXP_CFG>;
 		interrupt-parent = <&intc>;
-		#if 1
+		#if 0
 		interrupts = <92 IRQ_TYPE_LEVEL_HIGH 93 IRQ_TYPE_LEVEL_HIGH
 				94 IRQ_TYPE_LEVEL_HIGH 95 IRQ_TYPE_LEVEL_HIGH
 				96 IRQ_TYPE_LEVEL_HIGH 97 IRQ_TYPE_LEVEL_HIGH
@@ -468,6 +471,7 @@
 		interrupt-names = "macirq";
 		#endif
 		snps,tso;
+		sophgo,xlgmac;
 		snps,axi-config = <&xlgmac_axi_setup>;
 		snps,mtl-rx-config = <&xlg_mtl_rx_setup>;
 		snps,mtl-tx-config = <&xlg_mtl_tx_setup>;
@@ -478,11 +482,11 @@
 			full-duplex;
 		};
 	};
-
+#endif
 	aliases {
 		serial0 = &uart0;
 		ethernet0 = &ethernet0;
-		//dwcxlg0 = &dwcxlg0;
+		// dwcxlg0 = &dwcxlg0;
 	};
-#endif
+
 };

--- a/arch/riscv/boot/dts/sophgo/sg2260-rp-full.dts
+++ b/arch/riscv/boot/dts/sophgo/sg2260-rp-full.dts
@@ -16,15 +16,16 @@
 #include "sg2260-video-sys.dtsi"
 
 / {
+	/delete-node/ bm-emmc@703000A000;
 	aliases {
 		serial0 = &uart1;
 	};
 
 	chosen {
-		bootargs = "console=ttyS1,115200 earlycon rdinit=/init root=/dev/ram0 rw initrd=0x8b000000,32M maxcpus=4 no5lvl";
+		bootargs = "console=ttyS1,115200 earlycon rdinit=/init root=/dev/ram0 rw initrd=0x8b000000,32M maxcpus=64 no5lvl";
 		stdout-path = "serial0";
 	};
 };
 
 #include "sg2260-pcie-intc-rp.dtsi"
-#include "sg2260-pcie-5rc-rp.dtsi"
+// #include "sg2260-pcie-5rc-rp.dtsi"

--- a/drivers/clk/clk.c
+++ b/drivers/clk/clk.c
@@ -3308,7 +3308,7 @@ static int clk_dump_show(struct seq_file *s, void *data)
 }
 DEFINE_SHOW_ATTRIBUTE(clk_dump);
 
-#undef CLOCK_ALLOW_WRITE_DEBUGFS
+#define CLOCK_ALLOW_WRITE_DEBUGFS
 #ifdef CLOCK_ALLOW_WRITE_DEBUGFS
 /*
  * This can be dangerous, therefore don't provide any real compile time

--- a/drivers/clk/sophgo/clk-sg2044.c
+++ b/drivers/clk/sophgo/clk-sg2044.c
@@ -22,7 +22,6 @@ struct sg2044_pll_clock sg2044_root_pll_clks[] = {
 		.flags = CLK_GET_RATE_NOCACHE | CLK_GET_ACCURACY_NOCACHE,
 		.status_offset = 0x98,
 		.enable_offset = 0x9c,
-		.ini_flags = SG2044_CLK_RO,
 	}, {
 		.id = MPLL1_CLK,
 		.name = "mpll1_clock",
@@ -30,7 +29,6 @@ struct sg2044_pll_clock sg2044_root_pll_clks[] = {
 		.flags = CLK_GET_RATE_NOCACHE | CLK_GET_ACCURACY_NOCACHE,
 		.status_offset = 0x98,
 		.enable_offset = 0x9c,
-		.ini_flags = SG2044_CLK_RO,
 	}, {
 		.id = MPLL2_CLK,
 		.name = "mpll2_clock",
@@ -38,7 +36,6 @@ struct sg2044_pll_clock sg2044_root_pll_clks[] = {
 		.flags = CLK_GET_RATE_NOCACHE | CLK_GET_ACCURACY_NOCACHE,
 		.status_offset = 0x98,
 		.enable_offset = 0x9c,
-		.ini_flags = SG2044_CLK_RO,
 	}, {
 		.id = MPLL3_CLK,
 		.name = "mpll3_clock",
@@ -46,7 +43,6 @@ struct sg2044_pll_clock sg2044_root_pll_clks[] = {
 		.flags = CLK_GET_RATE_NOCACHE | CLK_GET_ACCURACY_NOCACHE,
 		.status_offset = 0x98,
 		.enable_offset = 0x9c,
-		.ini_flags = SG2044_CLK_RO,
 	}, {
 		.id = MPLL4_CLK,
 		.name = "mpll4_clock",
@@ -54,7 +50,6 @@ struct sg2044_pll_clock sg2044_root_pll_clks[] = {
 		.flags = CLK_GET_RATE_NOCACHE | CLK_GET_ACCURACY_NOCACHE,
 		.status_offset = 0x98,
 		.enable_offset = 0x9c,
-		.ini_flags = SG2044_CLK_RO,
 	}, {
 		.id = MPLL5_CLK,
 		.name = "mpll5_clock",
@@ -62,7 +57,6 @@ struct sg2044_pll_clock sg2044_root_pll_clks[] = {
 		.flags = CLK_GET_RATE_NOCACHE | CLK_GET_ACCURACY_NOCACHE,
 		.status_offset = 0x98,
 		.enable_offset = 0x9c,
-		.ini_flags = SG2044_CLK_RO,
 	}, {
 		.id = FPLL0_CLK,
 		.name = "fpll0_clock",
@@ -351,7 +345,7 @@ static const struct sg2044_gate_clock gate_clks[] = {
 	{ GATE_CLK_C2C0_TEST_PHY, "clk_gate_c2c0_test_phy", "clk_div_c2c0_test_phy",
 		CLK_SET_RATE_PARENT, 0x2000, 4, 0 },
 	{ GATE_CLK_TOP_50M, "clk_gate_top_50m", "clk_div_top_50m",
-		CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED, 0x2000, 1, 0 },
+		CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED | CLK_IS_CRITICAL, 0x2000, 1, 0 },
 	{ GATE_CLK_SC_RX, "clk_gate_sc_rx", "clk_gate_top_50m",
 		CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED, 0x2000, 12, 0 },
 	{ GATE_CLK_SC_RX_X0Y1, "clk_gate_sc_rx_x0y1", "clk_gate_top_50m",
@@ -391,7 +385,7 @@ static const struct sg2044_gate_clock gate_clks[] = {
 	{ GATE_CLK_SD, "clk_gate_sd", "clk_div_sd",
 		CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED, 0x2008, 3, 0 },
 	{ GATE_CLK_TOP_AXI0, "clk_gate_top_axi0", "clk_div_top_axi0",
-		CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED, 0x2008, 5, 0 },
+		CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED | CLK_IS_CRITICAL, 0x2008, 5, 0 },
 	{ GATE_CLK_100K_SD, "clk_gate_100k_sd", "clk_div_100k_sd",
 		CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED, 0x2008, 4, 0 },
 	{ GATE_CLK_100K_EMMC, "clk_gate_100k_emmc", "clk_div_100k_emmc",
@@ -437,7 +431,7 @@ static const struct sg2044_gate_clock gate_clks[] = {
 	{ GATE_CLK_INTC3, "clk_gate_intc3", "clk_gate_top_axi0",
 		CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED, 0x20, 23, 0 },
 	{ GATE_CLK_TOP_AXI_HSPERI, "clk_gate_top_axi_hsperi", "clk_div_top_axi_hsperi",
-		CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED, 0x2008, 6, 0 },
+		CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED | CLK_IS_CRITICAL, 0x2008, 6, 0 },
 	{ GATE_CLK_AXI_SD, "clk_gate_axi_sd", "clk_gate_top_axi_hsperi",
 		CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED, 0x2008, 2, 0 },
 	{ GATE_CLK_AXI_EMMC, "clk_gate_axi_emmc", "clk_gate_top_axi_hsperi",

--- a/drivers/clk/sophgo/clk.h
+++ b/drivers/clk/sophgo/clk.h
@@ -22,6 +22,7 @@
 
 #define PLL_CTRL_OFFSET	0xC4
 #define PLL_STAT_LOCK_OFFSET	0x10
+#define PLL_SELECT_OFFSET	0x2020
 #define CLK_MODE	0x4
 #define CLK_MODE_MASK	0x3
 
@@ -35,8 +36,8 @@
 
 #define div_mask(width) ((1 << (width)) - 1)
 #define TOP_PLL_CTRL(fbdiv, p1, p2, refdiv) \
-	(BIT(30) | BIT(28) | BIT(24) | ((p2 & 0x7) << 21) | \
-	((p1 & 0x7) << 18) | ((refdiv & 0x3f) << 12) | (fbdiv & 0xfff))
+	(BIT(30) | (0x2 << 27) | BIT(24) | (((p2 - 1) & 0x7) << 21) | \
+	(((p1 - 1) & 0x7) << 18) | ((refdiv & 0x3f) << 12) | (fbdiv & 0xfff))
 
 struct sg2044_pll_ctrl {
 	unsigned int mode;


### PR DESCRIPTION
1. parent clk should have CLK_IS_CRITICAL attribute for keep clk enable.
2. add mofidy pll function to let user use debugfs set mpll freq. when modify pll freq, must switch target pll to backup pll, then set the pll freq, finally switch back to target pll.
3. add clk for 100GE mac driver init.
4. now default peri dts have 4 uart, rp will use uart1, so let the bootargs also use ttyS1.
5. let rp default use 64 maxcpus in bootargs.
6. fix pll default frequency uncorrect bugs, the frequency should be calculate by (postdiv1 - 1) and (postdiv2 - 1).