### PR TITLE
riscv:drivers:clk fix pll can't set value greater then 2.4G

### DIFF
--- a/drivers/clk/sophgo/clk.c
+++ b/drivers/clk/sophgo/clk.c
@@ -443,9 +443,14 @@ static int sg2044_clk_pll_set_rate(struct clk_hw *hw, unsigned long rate,
 {
 	unsigned long flags;
 	unsigned int value;
-	int ret = 0;
+	int vcosel, ret = 0;
 	struct sg2044_pll_ctrl pctrl_table;
 	struct sg2044_pll_clock *sg2044_pll = to_sg2044_pll_clk(hw);
+
+	if (rate < (2400 * MHZ))
+		vcosel = 0x2;
+	else
+		vcosel = 0x3;
 
 	memset(&pctrl_table, 0, sizeof(struct sg2044_pll_ctrl));
 	spin_lock_irqsave(sg2044_pll->lock, flags);
@@ -457,6 +462,8 @@ static int sg2044_clk_pll_set_rate(struct clk_hw *hw, unsigned long rate,
 	}
 
 	sg2044_pll_read_l(sg2044_pll->syscon_top, sg2044_pll->id, &value);
+	value &= ~(0x3 << 16);
+	value |= (vcosel << 16);
 	sg2044_pll_write_l(sg2044_pll->syscon_top, sg2044_pll->id, value);
 	sg2044_pll_read(sg2044_pll->syscon_top, sg2044_pll->id, &value);
 	__get_pll_ctl_setting(&pctrl_table, rate, parent_rate);

--- a/drivers/clk/sophgo/clk.h
+++ b/drivers/clk/sophgo/clk.h
@@ -31,7 +31,7 @@
 #define FBDIV_MIN 8
 #define FBDIV_MAX 1066
 
-#define PLL_FREQ_MIN (16 * MHZ)
+#define PLL_FREQ_MIN (1600 * MHZ)
 #define PLL_FREQ_MAX (3200 * MHZ)
 
 #define div_mask(width) ((1 << (width)) - 1)


### PR DESCRIPTION
pll control register bit[17:16] is for vcosel, if vcosel is 0x2, pll range is 1.6G~2.4GHz, if vcosel is 0x3, pll range is 2.4G~ 3.2GHz. we must modify this bit when set pll values and limit the pll range 1.6G ~ 3.2GHz.