### PR TITLE
riscv: dts: update SG2044 reset/poweroff dts node name

### DIFF
--- a/arch/riscv/boot/dts/sophgo/bm1690-evb.dts
+++ b/arch/riscv/boot/dts/sophgo/bm1690-evb.dts
@@ -42,7 +42,7 @@
 
 &i2c1 {
 	sg2044_srst: sg2044-reset@17 {
-		compatible = "sg2044,reset";
+		compatible = "sophgo,sg2042-hwmon-mcu";
 		reg = <0x17>;
 	};
 };

--- a/arch/riscv/boot/dts/sophgo/sg2260-ap-full.dts
+++ b/arch/riscv/boot/dts/sophgo/sg2260-ap-full.dts
@@ -27,7 +27,7 @@
 
 &i2c1 {
 	sg2044_srst: sg2044-reset@17 {
-		compatible = "sg2044,reset";
+		compatible = "sophgo,sg2042-hwmon-mcu";
 		reg = <0x17>;
 	};
 };

--- a/arch/riscv/boot/dts/sophgo/sg2260-rp-full.dts
+++ b/arch/riscv/boot/dts/sophgo/sg2260-rp-full.dts
@@ -31,7 +31,7 @@
 
 &i2c1 {
 	sg2044_srst: sg2044-reset@17 {
-		compatible = "sg2044,reset";
+		compatible = "sophgo,sg2042-hwmon-mcu";
 		reg = <0x17>;
 	};
 };


### PR DESCRIPTION
SG2044 use the master branch code of Opensbi, same as SG2042.