### PR TITLE
drivers: soc: sophgo: eliminate compile warnings.

### DIFF
--- a/drivers/soc/sophgo/ap_sgcard/ap_sgcard.c
+++ b/drivers/soc/sophgo/ap_sgcard/ap_sgcard.c
@@ -437,7 +437,7 @@ static int host_int(struct sg_card *card, struct v_channel *channel)
 			channel->channel_index, request_action.request_id, request_action.type);
 
 		if (request_action.type == ERROR_REQUEST_RESPONSE || request_action.type > SETUP_C2C_REQUEST) {
-			pr_err("error type host request type is %d\n", request_action.type);
+			pr_err("error type host request type is %llu\n", request_action.type);
 			for (i = 0; i < sizeof(request_action) / sizeof(uint64_t); i++)
 				pr_err("offset:%d data:0x%llx\n", i, ((uint64_t *)(&request_action))[i]);
 		}

--- a/drivers/tty/Kconfig
+++ b/drivers/tty/Kconfig
@@ -415,3 +415,4 @@ endif # TTY
 
 source "drivers/tty/serdev/Kconfig"
 source "drivers/tty/vtty/Kconfig"
+


### PR DESCRIPTION
1. new line should be at the end of drivers/tty/Kconfig.
2. In ap_sgcard.c:440, the type is long long unsigned.