### PR TITLE
dts: riscv: In bm1690 pcie mode, change rp used memory.

### DIFF
--- a/arch/riscv/boot/dts/sophgo/bm1690-cdm-rp.dts
+++ b/arch/riscv/boot/dts/sophgo/bm1690-cdm-rp.dts
@@ -13,7 +13,7 @@
 / {
 	memory@80000000 {
 		device_type = "memory";
-		reg = <0x0000000c 0x00000000 0x00000004 0x00000000>;
+		reg = <0x00000001 0xc0200000 0x00000000 0x1fe00000>;
 	};
 
 	uart1: serial@7030000000 {
@@ -45,7 +45,7 @@
 		};
 
 	chosen {
-		bootargs = "console=ttyS0,115200 earlycon rdinit=/init root=/dev/ram0 rw initrd=0xc0b000000,128M maxcpus=64 no5lvl";
+		bootargs = "console=ttyS0,115200 earlycon rdinit=/init root=/dev/ram0 rw initrd=0x1cb000000,128M maxcpus=64 no5lvl";
 		stdout-path = "serial0";
 	};
 };

--- a/arch/riscv/boot/dts/sophgo/sg2044-peri-sys.dtsi
+++ b/arch/riscv/boot/dts/sophgo/sg2044-peri-sys.dtsi
@@ -454,19 +454,19 @@
 			<&div_clk GATE_CLK_CXP_CFG>;
 		interrupt-parent = <&intc>;
 		#if 0
-		interrupts = <92 IRQ_TYPE_LEVEL_HIGH 93 IRQ_TYPE_LEVEL_HIGH
-				94 IRQ_TYPE_LEVEL_HIGH 95 IRQ_TYPE_LEVEL_HIGH
-				96 IRQ_TYPE_LEVEL_HIGH 97 IRQ_TYPE_LEVEL_HIGH
-				98 IRQ_TYPE_LEVEL_HIGH 99 IRQ_TYPE_LEVEL_HIGH
-				100 IRQ_TYPE_LEVEL_HIGH
+		interrupts = <92 IRQ_TYPE_LEVEL_HIGH
+				93 IRQ_TYPE_LEVEL_HIGH 94 IRQ_TYPE_LEVEL_HIGH
+				95 IRQ_TYPE_LEVEL_HIGH 96 IRQ_TYPE_LEVEL_HIGH
+				97 IRQ_TYPE_LEVEL_HIGH 98 IRQ_TYPE_LEVEL_HIGH
+				99 IRQ_TYPE_LEVEL_HIGH 100 IRQ_TYPE_LEVEL_HIGH
 				109 IRQ_TYPE_LEVEL_HIGH 110 IRQ_TYPE_LEVEL_HIGH
 				111 IRQ_TYPE_LEVEL_HIGH 112 IRQ_TYPE_LEVEL_HIGH
 				113 IRQ_TYPE_LEVEL_HIGH 114 IRQ_TYPE_LEVEL_HIGH
 				115 IRQ_TYPE_LEVEL_HIGH 116 IRQ_TYPE_LEVEL_HIGH>;
 		interrupt-names = "macirq", "tx_ch0", "tx_ch1", "tx_ch2", "tx_ch3",
-				  "tx_ch4", "tx_ch5", "tx_ch6", "rx_ch0", "rx_ch1",
-				  "rx_ch2", "rx_ch3", "rx_ch4", "rx_ch5", "rx_ch6",
-				  "rx_ch7";
+					"tx_ch4", "tx_ch5", "tx_ch6", "tx_ch7",
+					"rx_ch0", "rx_ch1", "rx_ch2", "rx_ch3",
+					"rx_ch4", "rx_ch5", "rx_ch6", "rx_ch7";
 		snps,multi_msi_en;
 		#else
 		interrupts = <92 IRQ_TYPE_LEVEL_HIGH>;


### PR DESCRIPTION
zsbl address: 0x1d4000000
opensbi address: 0x1c0000000
kernel address: 0x1c0200000
dtb address: 0x1c8000000
ramfs address: 0x1cb000000