### PR TITLE
dts: riscv: In bm1690 pcie mode, change rp used memory.

### DIFF
--- a/arch/riscv/boot/dts/sophgo/bm1690-cdm-rp.dts
+++ b/arch/riscv/boot/dts/sophgo/bm1690-cdm-rp.dts
@@ -13,7 +13,7 @@
 / {
 	memory@80000000 {
 		device_type = "memory";
-		reg = <0x0000000c 0x00000000 0x00000004 0x00000000>;
+		reg = <0x00000001 0xc0200000 0x00000000 0x1fe00000>;
 	};
 
 	uart1: serial@7030000000 {
@@ -45,7 +45,7 @@
 		};
 
 	chosen {
-		bootargs = "console=ttyS0,115200 earlycon rdinit=/init root=/dev/ram0 rw initrd=0xc0b000000,128M maxcpus=64 no5lvl";
+		bootargs = "console=ttyS0,115200 earlycon rdinit=/init root=/dev/ram0 rw initrd=0x1cb000000,128M maxcpus=64 no5lvl";
 		stdout-path = "serial0";
 	};
 };


### PR DESCRIPTION
zsbl address: 0x1d4000000
opensbi address: 0x1c0000000
kernel address: 0x1c0200000
dtb address: 0x1c8000000
ramfs address: 0x1cb000000