### PR TITLE
SG2044 MSI: ACPI:

### DIFF
--- a/drivers/irqchip/irq-sg2044-msi.c
+++ b/drivers/irqchip/irq-sg2044-msi.c
@@ -331,6 +331,11 @@ static int sg2044_msi_probe(struct platform_device *pdev)
 			dev_name(&msi_data->pdev->dev));
 	msi_data = data;
 
+#ifdef CONFIG_ACPI
+	if (!acpi_disabled)
+		acpi_dev_clear_dependencies(ACPI_COMPANION(fwnode->dev));
+#endif
+
 	return ret;
 
 out:


### PR DESCRIPTION
SG2044 is PLIC based platforms, which means it doesn't support MSI natively. PCIe MSIs should routed to a dedicated MSI controller. This MSI controller wire interrupts to PLIC. So PCIe host need such MSI controller initialized before.

This commit deal with dependency delcared in ACPI DSDT. Linux kernel drivers of MSI controller should use
acpi_dev_clear_dependencies to nofity ACPI probe framework that it has done. After which, ACPI probe continue with PCIe hosts.