### PR TITLE
of: fdt: Fix fdt CRC check failed when ACPI is enabled

### DIFF
--- a/drivers/of/fdt.c
+++ b/drivers/of/fdt.c
@@ -1214,9 +1214,11 @@ void __init unflatten_device_tree(void)
 {
 	void *fdt = initial_boot_params;
 
+#ifndef CONFIG_RISCV || CONFIG_ARM64
 	/* Don't use the bootloader provided DTB if ACPI is enabled */
 	if (!acpi_disabled)
 		fdt = NULL;
+#endif
 
 	/*
 	 * Populate an empty root node when ACPI is enabled or bootloader


### PR DESCRIPTION
The EFI Stub will generate an empty DTB and append the /chosen node to it when booting ARM64 and RISC-V platfroms with ACPI enabled. That means the DTB is not empty.

The commit 7b937cc ignores the above ACPI boot situation, which forces the fdt to be NULL when ACPI is enabled, resulting in the following issue.
[    3.491475] OF: fdt: not creating '/sys/firmware/fdt': CRC check failed