### PR TITLE
riscv: sophgo: dts: add power key for pioneer box

### DIFF
--- a/arch/riscv/boot/dts/sophgo/sg2042-milkv-pioneer.dts
+++ b/arch/riscv/boot/dts/sophgo/sg2042-milkv-pioneer.dts
@@ -5,12 +5,27 @@
 
 #include "sg2042.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
 / {
 	model = "Milk-V Pioneer";
 	compatible = "milkv,pioneer", "sophgo,sg2042";
 
 	chosen {
 		stdout-path = "serial0";
+	};
+
+	gpio-power {
+		compatible = "gpio-keys";
+
+		key-power {
+			label = "Power Key";
+			linux,code = <KEY_POWER>;
+			gpios = <&port0a 22 GPIO_ACTIVE_HIGH>;
+			linux,input-type = <EV_KEY>;
+			debounce-interval = <100>;
+		};
 	};
 };
 


### PR DESCRIPTION
There is a power button on the front panel of the pioneer box. Short pressing the button will trigger the onboard MCU to notify SG2042 through GPIO22 to enter the power-off process.

Patch from https://lore.kernel.org/all/cover.1728350655.git.unicorn_wang@outlook.com/