### PR TITLE
drivers: acpi: add MSI controller's HID to acpi_honor_dep_ids

### DIFF
--- a/drivers/acpi/scan.c
+++ b/drivers/acpi/scan.c
@@ -861,6 +861,7 @@ static const char * const acpi_honor_dep_ids[] = {
 	"RSCV0001", /* RISC-V PLIC */
 	"RSCV0002", /* RISC-V APLIC */
 	"PNP0C0F",  /* PCI Link Device */
+	"SGPH0002", /* Sophgo MSI-controller*/
 	NULL
 };
 


### PR DESCRIPTION
 - We found that the previous dependency description for PCI was incomplete, as there is a description of INTX functionality in PCI in ACPI, resulting in the "honor_deps" being seen as true. In fact, now the '_DEP' described in the ACPI table does not exist in "acpi_honor_dep_ids" when checked in the kernel, and this dependency is invalid. When we remove the description of INTX functionality in ACPI, the previous PCI device will still be probed before the MSI controller and unable to function properly.

 - We should ensure that all dependencies added to the device are valid, and all dependencies are probed before the device.

 - Like:"Interrupt controller <-- Link Device + MSI Controller <-- PCI Host bridge".