### PR TITLE
dts: sophgo: let each cpu only use one uart.

### DIFF
--- a/arch/riscv/boot/dts/sophgo/bm1690-evb-ap.dts
+++ b/arch/riscv/boot/dts/sophgo/bm1690-evb-ap.dts
@@ -17,8 +17,12 @@
 / {
 	/delete-node/ memory@80200000;
 	/delete-node/ bm-emmc@703000A000;
-    /delete-node/ bm-sd@703000B000;
+	/delete-node/ bm-sd@703000B000;
 };
+
+/delete-node/ &uart1;
+/delete-node/ &uart2;
+/delete-node/ &uart3;
 
 / {
 	memory@80200000 {
@@ -78,7 +82,7 @@
 				compatible = "sophgo,sophgo-card";
 				reg =  <0x1e  0xf8000000 0x00000000 0x01400000>,
 					<0x70 0x101ff000 0x00000000 0x00001000>,
-                    <0x70 0x50000000 0x00000000 0x00001000>;
+					<0x70 0x50000000 0x00000000 0x00001000>;
 				reg-names = "share-memory", "config_file", "top-reg";
 
 				host-channel-num = <1>;

--- a/arch/riscv/boot/dts/sophgo/bm1690-evb.dts
+++ b/arch/riscv/boot/dts/sophgo/bm1690-evb.dts
@@ -14,7 +14,7 @@
 #include "bm1690-tpu-sys.dtsi"
 #include "bm1690-video-sys-soc.dtsi"
 #include "sg2044-pcie-intc.dtsi"
-//#include "sg2044-pcie-5rc-rp.dtsi"
+//#include "sg2044-pcie-5rc.dtsi"
 
 / {
 	/delete-node/ bm-emmc@703000A000;
@@ -30,7 +30,7 @@
 	};
 
 	chosen {
-		bootargs = "console=ttyS1,115200 earlycon rdinit=/init root=/dev/ram0 rw initrd=0xc0b000000,32M maxcpus=64 no5lvl";
+		bootargs = "console=ttyS0,115200 earlycon rdinit=/init root=/dev/ram0 rw initrd=0xc0b000000,32M maxcpus=64 no5lvl";
 		stdout-path = "serial0";
 	};
 };
@@ -45,3 +45,8 @@
 		reg = <0x17>;
 	};
 };
+
+/delete-node/ &uart0;
+/delete-node/ &uart2;
+/delete-node/ &uart3;
+


### PR DESCRIPTION
ap use uart0, rp use uart1.