### PR TITLE
irqchip/thead-c900-aclint-sswi: Add ACPI support

### DIFF
--- a/drivers/irqchip/Makefile
+++ b/drivers/irqchip/Makefile
@@ -97,9 +97,13 @@ obj-$(CONFIG_QCOM_MPM)			+= irq-qcom-mpm.o
 obj-$(CONFIG_CSKY_MPINTC)		+= irq-csky-mpintc.o
 obj-$(CONFIG_CSKY_APB_INTC)		+= irq-csky-apb-intc.o
 obj-$(CONFIG_RISCV_INTC)		+= irq-riscv-intc.o
+
+ifndef CONFIG_THEAD_C900_ACLINT_SSWI
 obj-$(CONFIG_RISCV_APLIC)		+= irq-riscv-aplic-main.o irq-riscv-aplic-direct.o
 obj-$(CONFIG_RISCV_APLIC_MSI)		+= irq-riscv-aplic-msi.o
 obj-$(CONFIG_RISCV_IMSIC)		+= irq-riscv-imsic-state.o irq-riscv-imsic-early.o irq-riscv-imsic-platform.o
+endif
+
 obj-$(CONFIG_SIFIVE_PLIC)		+= irq-sifive-plic.o
 obj-$(CONFIG_STARFIVE_JH8100_INTC)	+= irq-starfive-jh8100-intc.o
 obj-$(CONFIG_THEAD_C900_ACLINT_SSWI)	+= irq-thead-c900-aclint-sswi.o


### PR DESCRIPTION
Add ACPI support in ACLINT-SSWI early probe. Treat ACLINT-SSWI as a fake IMSIC that can only handle IPIs in a software manner. Use the IMSIC-related fields in the MADT table to obtain the register base address of ACLINT-SSWI.

Note that when booting with ACPI, ACLINT-SSWI cannot coexist with the standard IMSIC driver, as the IMSIC driver parses the ACPI table entries before ACLINT-SSWI, resulting in error logs. Therefore, we disable the IMSIC-related kernel drivers.