### PR TITLE
drivers: Add i2c and spi ACPI support

### DIFF
--- a/drivers/acpi/acpi_apd.c
+++ b/drivers/acpi/acpi_apd.c
@@ -40,7 +40,7 @@ struct apd_private_data {
 	const struct apd_device_desc *dev_desc;
 };
 
-#if defined(CONFIG_X86_AMD_PLATFORM_DEVICE) || defined(CONFIG_ARM64)
+#if defined(CONFIG_X86_AMD_PLATFORM_DEVICE) || defined(CONFIG_ARM64) || defined(CONFIG_RISCV)
 #define APD_ADDR(desc)	((unsigned long)&desc)
 
 static int acpi_apd_setup(struct apd_private_data *pdata)
@@ -183,6 +183,17 @@ static const struct apd_device_desc hip08_spi_desc = {
 };
 #endif /* CONFIG_ARM64 */
 
+#ifdef CONFIG_RISCV
+static const struct apd_device_desc sophgo_i2c_desc = {
+	.setup = acpi_apd_setup,
+	.fixed_clk_rate = 100000000,
+};
+static const struct apd_device_desc sophgo_spi_desc = {
+	.setup = acpi_apd_setup,
+	.fixed_clk_rate = 250000000,
+};
+#endif /* CONFIG_RISCV */
+
 #endif
 
 /*
@@ -253,6 +264,11 @@ static const struct acpi_device_id acpi_apd_device_ids[] = {
 	{ "HISI0173", APD_ADDR(hip08_spi_desc) },
 	{ "NXP0001", APD_ADDR(nxp_i2c_desc) },
 #endif
+#ifdef CONFIG_RISCV
+	{ "SOPH0003", APD_ADDR(sophgo_i2c_desc) },
+	{ "SOPH0004", APD_ADDR(sophgo_spi_desc) },
+#endif
+
 	{ }
 };
 

--- a/drivers/i2c/busses/i2c-designware-platdrv.c
+++ b/drivers/i2c/busses/i2c-designware-platdrv.c
@@ -360,6 +360,7 @@ static const struct acpi_device_id dw_i2c_acpi_match[] = {
 	{ "INT3432", 0 },
 	{ "INT3433", 0 },
 	{ "INTC10EF", 0 },
+	{ "SOPH0003", 0 },
 	{}
 };
 MODULE_DEVICE_TABLE(acpi, dw_i2c_acpi_match);

--- a/drivers/spi/spi-dw-mmio.c
+++ b/drivers/spi/spi-dw-mmio.c
@@ -344,7 +344,7 @@ static int dw_spi_mmio_probe(struct platform_device *pdev)
 	if (dws->irq < 0)
 		return dws->irq; /* -ENXIO */
 
-	dwsmmio->clk = devm_clk_get_optional_enabled(&pdev->dev, NULL);
+	dwsmmio->clk = devm_clk_get_enabled(&pdev->dev, NULL);
 	if (IS_ERR(dwsmmio->clk))
 		return PTR_ERR(dwsmmio->clk);
 
@@ -362,10 +362,7 @@ static int dw_spi_mmio_probe(struct platform_device *pdev)
 
 	dws->bus_num = pdev->id;
 
-	if (pdev->dev.of_node)
-		dws->max_freq = clk_get_rate(dwsmmio->clk);
-	else
-		device_property_read_u32(&pdev->dev, "clock-frequency", &dws->max_freq);
+	dws->max_freq = clk_get_rate(dwsmmio->clk);
 
 	if (device_property_read_u32(&pdev->dev, "reg-io-width",
 				     &dws->reg_io_width))
@@ -429,6 +426,7 @@ MODULE_DEVICE_TABLE(of, dw_spi_mmio_of_match);
 #ifdef CONFIG_ACPI
 static const struct acpi_device_id dw_spi_mmio_acpi_match[] = {
 	{"HISI0173", (kernel_ulong_t)dw_spi_pssi_init},
+	{"SOPH0004", (kernel_ulong_t)dw_spi_pssi_init},
 	{},
 };
 MODULE_DEVICE_TABLE(acpi, dw_spi_mmio_acpi_match);


### PR DESCRIPTION
 - Revert the previous compatible modification of SPI.

 - Add SOPH0003 and SOPH0004 to the ACPI APD support list to ensure correct clock settings for the I2C and SPI devices on the SOPHGO platforms.