### PR TITLE
drivers: adjust registration priority of riscv-plic driver

### DIFF
--- a/drivers/irqchip/irq-sifive-plic.c
+++ b/drivers/irqchip/irq-sifive-plic.c
@@ -726,7 +726,12 @@ static struct platform_driver plic_driver = {
 	},
 	.probe = plic_platform_probe,
 };
-builtin_platform_driver(plic_driver);
+
+static int __init plic_init(void)
+{
+	return platform_driver_register(&plic_driver);
+}
+arch_initcall(plic_init);
 
 static int __init plic_early_probe(struct device_node *node,
 				   struct device_node *parent)


### PR DESCRIPTION
Sort out the loading order of PCIe dependencies and fix the warning caused by a race condition between the delayed execution of the PCIe driver and pci_sysfs_init when the dependencies are not satisfied.

[ 5.085835] sysfs: cannot create duplicate filename '/devices/pci0002:00/0002:00:00.0/resource0' [ 5.106935] CPU: 17 UID: 0 PID: 521 Comm: kworker/u274:2 Not tainted 6.12.14-0.0.0.0.riscv64 #1 [ 5.106943] Hardware name: SOPHGO SG2044EVB/SG2044EVB, BIOS [ 5.106948] Workqueue: events_unbound acpi_scan_clear_dep_fn [ 5.106962] Call Trace:
[ 5.106965] [<ffffffff80006ebe>] dump_backtrace+0x28/0x30 [ 5.106976] [<ffffffff80ddc3ca>] show_stack+0x38/0x44 [ 5.106986] [<ffffffff80df315e>] dump_stack_lvl+0x6a/0x82 [ 5.106993] [<ffffffff80df318e>] dump_stack+0x18/0x20 [ 5.106998] [<ffffffff8037d5d4>] sysfs_warn_dup+0x62/0x7a [ 5.107007] [<ffffffff8037d408>] sysfs_add_bin_file_mode_ns+0x96/0xb0 [ 5.107012] [<ffffffff8037d474>] sysfs_create_bin_file+0x52/0x6e [ 5.107018] [<ffffffff80769b70>] pci_create_resource_files+0x9c/0x15a [ 5.107026] [<ffffffff8076a4ec>] pci_create_sysfs_dev_files+0x22/0x2e [ 5.107031] [<ffffffff80749632>] pci_bus_add_device+0x38/0xec [ 5.107038] [<ffffffff80749722>] pci_bus_add_devices+0x3c/0x7a [ 5.107043] [<ffffffff807e2590>] acpi_pci_root_add+0x33c/0x7ce [ 5.107050] [<ffffffff807d9390>] acpi_bus_attach+0x174/0x268 [ 5.107054] [<ffffffff807d94b4>] acpi_scan_clear_dep_fn+0x30/0x64 [ 5.107059] [<ffffffff8003e1e2>] process_one_work+0x18e/0x33a [ 5.107066] [<ffffffff8003edfe>] worker_thread+0x27a/0x3ba [ 5.107071] [<ffffffff800464c6>] kthread+0xc2/0xe2 [ 5.107076] [<ffffffff80dffa9e>] ret_from_fork+0xe/0x1c