### PR TITLE
pcie: fix pcie-cadence-sophgo.c build error

### DIFF
--- a/drivers/pci/controller/cadence/pcie-cadence-sophgo.c
+++ b/drivers/pci/controller/cadence/pcie-cadence-sophgo.c
@@ -400,7 +400,7 @@ static int cdns_pcie_msi_init(struct cdns_mango_pcie_rc *rc)
 	return 0;
 }
 
-static int cdns_pcie_host_init(struct device *dev, struct cdns_mango_pcie_rc *rc)
+static int sophgo_cdns_pcie_host_init(struct device *dev, struct cdns_mango_pcie_rc *rc)
 {
 	int err;
 
@@ -882,7 +882,7 @@ static int cdns_pcie_host_probe(struct platform_device *pdev)
 		goto err_get_sync;
 	}
 
-	ret = cdns_pcie_host_init(dev, rc);
+	ret = sophgo_cdns_pcie_host_init(dev, rc);
 	if (ret)
 		goto err_init;
 


### PR DESCRIPTION
Signed-off-by: haijiao.liu <haijiao.liu@sophgo.com>

Fix compilation errors caused by function type mismatch.

drivers/pci/controller/cadence/pcie-cadence-sophgo.c:403:12: error: conflicting types for 'cdns_pcie_host_init'; have 'int(struct device *, struct cdns_mango_pcie_rc *)'
  403 | static int cdns_pcie_host_init(struct device *dev, struct cdns_mango_pcie_rc *rc)
      |            ^~~~~~~~~~~~~~~~~~~
In file included from drivers/pci/controller/cadence/pcie-cadence-sophgo.c:16:
drivers/pci/controller/cadence/pcie-cadence.h:519:5: note: previous declaration of 'cdns_pcie_host_init' with type 'int(struct cdns_pcie_rc *)'
  519 | int cdns_pcie_host_init(struct cdns_pcie_rc *rc);
      |     ^~~~~~~~~~~~~~~~~~~