### PR TITLE
drivers: i2c: Add ACPI support for Sophgo I2C Controller

### DIFF
--- a/drivers/acpi/acpi_apd.c
+++ b/drivers/acpi/acpi_apd.c
@@ -40,8 +40,9 @@ struct apd_private_data {
 	const struct apd_device_desc *dev_desc;
 };
 
-#if defined(CONFIG_X86_AMD_PLATFORM_DEVICE) || \
-defined(CONFIG_ARM64) || defined(CONFIG_SW64)
+#if defined(CONFIG_X86_AMD_PLATFORM_DEVICE) || defined(CONFIG_ARM64) || \
+    defined(CONFIG_SW64) || defined(CONFIG_RISCV)
+
 #define APD_ADDR(desc)	((unsigned long)&desc)
 
 static int acpi_apd_setup(struct apd_private_data *pdata)
@@ -205,6 +206,13 @@ static int sw64_acpi_apd_setup(struct apd_private_data *pdata)
 }
 #endif /* CONFIG_SW64 */
 
+#ifdef CONFIG_RISCV
+static const struct apd_device_desc sophgo_i2c_desc = {
+	.setup = acpi_apd_setup,
+	.fixed_clk_rate = 100000000,
+};
+#endif
+
 #endif
 
 /*
@@ -277,6 +285,9 @@ static const struct acpi_device_id acpi_apd_device_ids[] = {
 #ifdef CONFIG_SW64
 	{ "SUNW0005", APD_ADDR(sunway_i2c_desc) },
 	{ "SUNW0008", APD_ADDR(sunway_spi_desc) },
+#endif
+#ifdef CONFIG_RISCV
+	{ "SOPH0003", APD_ADDR(sophgo_i2c_desc) },
 #endif
 	{ }
 };

--- a/drivers/i2c/busses/i2c-designware-platdrv.c
+++ b/drivers/i2c/busses/i2c-designware-platdrv.c
@@ -58,6 +58,7 @@ static const struct acpi_device_id dw_i2c_acpi_match[] = {
 	{ "HISI02A3", 0 },
 	{ "HYGO0010", ACCESS_INTR_MASK },
 	{ "SUNW0005", MODEL_SUNWAY },
+	{ "SOPH0003", 0 },
 	{ }
 };
 MODULE_DEVICE_TABLE(acpi, dw_i2c_acpi_match);


### PR DESCRIPTION
Add SOPH0003 to the ACPI APD support list to ensure correct clock settings for the I2C devices on the Sophgo SG2044 platforms.