### PR TITLE
drivers: spi: Add ACPI support for Sophgo SPI Controller

### DIFF
--- a/drivers/acpi/acpi_apd.c
+++ b/drivers/acpi/acpi_apd.c
@@ -211,6 +211,11 @@ static const struct apd_device_desc sophgo_i2c_desc = {
 	.setup = acpi_apd_setup,
 	.fixed_clk_rate = 100000000,
 };
+
+static const struct apd_device_desc sophgo_spi_desc = {
+	.setup = acpi_apd_setup,
+	.fixed_clk_rate = 250000000,
+};
 #endif
 
 #endif
@@ -288,6 +293,7 @@ static const struct acpi_device_id acpi_apd_device_ids[] = {
 #endif
 #ifdef CONFIG_RISCV
 	{ "SOPH0003", APD_ADDR(sophgo_i2c_desc) },
+	{ "SOPH0004", APD_ADDR(sophgo_spi_desc) },
 #endif
 	{ }
 };

--- a/drivers/spi/spi-dw-mmio.c
+++ b/drivers/spi/spi-dw-mmio.c
@@ -439,6 +439,7 @@ MODULE_DEVICE_TABLE(of, dw_spi_mmio_of_match);
 #ifdef CONFIG_ACPI
 static const struct acpi_device_id dw_spi_mmio_acpi_match[] = {
 	{"HISI0173", (kernel_ulong_t)dw_spi_pssi_init},
+	{"SOPH0004", (kernel_ulong_t)dw_spi_pssi_init},
 	{},
 };
 MODULE_DEVICE_TABLE(acpi, dw_spi_mmio_acpi_match);


### PR DESCRIPTION
Add SOPH0004 to the ACPI APD support list to ensure correct clock settings for the SPI devices on the Sophgo SG2044 platforms.