### PR TITLE
irq: ipi-mux: Avoid the problem of smp startup hanging

### DIFF
--- a/kernel/irq/ipi-mux.c
+++ b/kernel/irq/ipi-mux.c
@@ -83,7 +83,10 @@ static void ipi_mux_send_mask(struct irq_data *d, const struct cpumask *mask)
 		 * dependency on the result of atomic_read() below, which is
 		 * itself already ordered after the vIPI flag write.
 		 */
-		if (!(pending & ibit) && (atomic_read(&icpu->enable) & ibit))
+		if (!(atomic_read(&icpu->enable) & ibit))
+			continue;
+
+		if (!(pending & ibit) || (system_state < SYSTEM_RUNNING))
 			ipi_mux_send(cpu);
 	}
 }


### PR DESCRIPTION
SG2042 server has 128 CPUs, but it may hang at the following position during startup. Add code to avoid this problem.

[    0.722843] cpu1: Ratio of byte access time to unaligned word access is 5.07, unaligned accesses are fast
[    0.792854] cpu2: Ratio of byte access time to unaligned word access is 5.16, unaligned accesses are fast