### PR TITLE
sophgo/dw-pcie: Remove buggy static variable phb_dev

### DIFF
--- a/drivers/pci/controller/dwc/pcie-dw-sophgo.c
+++ b/drivers/pci/controller/dwc/pcie-dw-sophgo.c
@@ -2023,12 +2023,9 @@ builtin_platform_driver(sophgo_dw_pcie_driver);
 
 #if defined(CONFIG_ACPI) && defined(CONFIG_PCI_QUIRKS)
 
-static struct device *phb_dev;
-struct fwnode_handle *pci_host_bridge_acpi_get_fwnode(struct device *dev);
-
-struct fwnode_handle *pci_host_bridge_acpi_get_fwnode(struct device *dev)
+static struct fwnode_handle *pci_host_bridge_acpi_get_fwnode(struct device *dev)
 {
-	return acpi_fwnode_handle(to_acpi_device(phb_dev));
+	return acpi_fwnode_handle(to_acpi_device(dev));
 }
 
 static int sophgo_pcie_init(struct pci_config_window *cfg)
@@ -2049,8 +2046,6 @@ static int sophgo_pcie_init(struct pci_config_window *cfg)
 	if (!pcie)
 		return -ENOMEM;
 
-	phb_dev = dev;
-	pcie->dev = dev;
 	pp = &pcie->pp;
 
 	ret = acpi_get_rc_target_num_resources(dev, "SOPH0000", root->segment, res, 4);


### PR DESCRIPTION
A static variable named phb_dev is used to record a device instance then it will be used in function pci_host_bridge_acpi_get_fwnode. But this is not needed. Even more, it is a bug if sophgo_pcie_init and pci_host_bridge_acpi_get_fwnode are not called in pair for one PCIe controller.