### PR TITLE
sophgo/dw-pcie: Restore dev assignment for resources access

### DIFF
--- a/drivers/pci/controller/dwc/pcie-dw-sophgo.c
+++ b/drivers/pci/controller/dwc/pcie-dw-sophgo.c
@@ -2046,6 +2046,7 @@ static int sophgo_pcie_init(struct pci_config_window *cfg)
 	if (!pcie)
 		return -ENOMEM;
 
+	pcie->dev = dev;
 	pp = &pcie->pp;
 
 	ret = acpi_get_rc_target_num_resources(dev, "SOPH0000", root->segment, res, 4);


### PR DESCRIPTION
The commit "sophgo/dw-pcie: Remove buggy static variable phb_dev" accidentally removed the critical assignment `pcie->dev = dev;` in sophgo_pcie_init().