### PR TITLE
riscv: select ARCH_PROC_KCORE_TEXT

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -914,6 +914,9 @@ config PORTABLE
 	select MMU
 	select OF
 
+config ARCH_PROC_KCORE_TEXT
+	def_bool y
+
 menu "Power management options"
 
 source "kernel/power/Kconfig"


### PR DESCRIPTION
This adds a separate segment for kernel text in /proc/kcore, which has a different address than the direct linear map.


Link: https://lore.kernel.org/r/mvmh6m758ao.fsf@suse.de