### PR TITLE
Fixbug: dwmac phy_node with wrong types

### DIFF
--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-rk.c
+++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-rk.c
@@ -1687,7 +1687,7 @@ static int rk_gmac_clk_init(struct plat_stmmacenet_data *plat)
 	}
 
 	if (plat->phy_node && bsp_priv->integrated_phy) {
-		bsp_priv->clk_phy = of_clk_get(plat->phy_node, 0);
+		bsp_priv->clk_phy = of_clk_get(to_of_node(plat->phy_node), 0);
 		ret = PTR_ERR_OR_ZERO(bsp_priv->clk_phy);
 		if (ret)
 			return dev_err_probe(dev, ret, "Cannot get PHY clock\n");
@@ -1851,10 +1851,10 @@ static struct rk_priv_data *rk_gmac_setup(struct platform_device *pdev,
 	}
 
 	if (plat->phy_node) {
-		bsp_priv->integrated_phy = of_property_read_bool(plat->phy_node,
+		bsp_priv->integrated_phy = of_property_read_bool(to_of_node(plat->phy_node),
 								 "phy-is-integrated");
 		if (bsp_priv->integrated_phy) {
-			bsp_priv->phy_reset = of_reset_control_get(plat->phy_node, NULL);
+			bsp_priv->phy_reset = of_reset_control_get(to_of_node(plat->phy_node), NULL);
 			if (IS_ERR(bsp_priv->phy_reset)) {
 				dev_err(&pdev->dev, "No PHY reset control found.\n");
 				bsp_priv->phy_reset = NULL;

--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
+++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
@@ -956,7 +956,7 @@ static int sun8i_dwmac_set_syscon(struct device *dev,
 		/* Force EPHY xtal frequency to 24MHz. */
 		reg |= H3_EPHY_CLK_SEL;
 
-		ret = of_mdio_parse_addr(dev, plat->phy_node);
+		ret = of_mdio_parse_addr(dev, to_of_node(plat->phy_node));
 		if (ret < 0) {
 			dev_err(dev, "Could not parse MDIO addr\n");
 			return ret;


### PR DESCRIPTION
We have changed phy_node in struct plat_stmmacenet_data from struct device_node * to struct fwnode *. Because on ACPI boot, we need parse PHY from DSDT instead of device tree. So a fwnode is needed. But some of drivers use this member to parse PHY from device tree. This patch convert fwnode to device_node at where other drivers who need this member.