### PR TITLE
riscv:sophgo:bm1690: default enable clk for apb_timer1.

### DIFF
--- a/arch/riscv/boot/dts/sophgo/bm1690e-peri-sys.dtsi
+++ b/arch/riscv/boot/dts/sophgo/bm1690e-peri-sys.dtsi
@@ -74,7 +74,7 @@
 			reg-io-width = <4>;
 		};
 
-        uart4: serial@7030004000 {
+		uart4: serial@7030004000 {
 			compatible = "sophgo,sg2044-uart", "snps,dw-apb-uart";
 			reg = <0x00000070 0x30004000 0x00000000 0x00001000>;
 			interrupt-parent = <&intc>;
@@ -294,6 +294,79 @@
 			clocks = <&div_clk GATE_CLK_EFUSE>,
 				 <&div_clk GATE_CLK_APB_EFUSE>;
 			num_cells = <256>;
+		};
+
+		ddrc@0 {
+			compatible = "sophgo,ddrc";
+
+			reg = <0x6b 0x40000000 0x00000000 0x04000000>;
+			interrupt-parent = <&intc>;
+			interrupts = <47 IRQ_TYPE_LEVEL_HIGH>;
+			// trigger_error_index = <0x0201060c>;
+			ddrc_id = <0>;
+		};
+		ddrc@1 {
+			compatible = "sophgo,ddrc";
+
+			reg = <0x6b 0x50000000 0x00000000 0x04000000>;
+			interrupt-parent = <&intc>;
+			interrupts = <48 IRQ_TYPE_LEVEL_HIGH>;
+			// trigger_error_index = <0x0201060c>;
+			ddrc_id = <1>;
+		};
+		ddrc@2 {
+			compatible = "sophgo,ddrc";
+
+			reg = <0x6b 0x54000000 0x00000000 0x04000000>;
+			interrupt-parent = <&intc>;
+			interrupts = <49 IRQ_TYPE_LEVEL_HIGH>;
+			// trigger_error_index = <0x0201060c>;
+			ddrc_id = <2>;
+		};
+		ddrc@3 {
+			compatible = "sophgo,ddrc";
+
+			reg = <0x6b 0x60000000 0x00000000 0x04000000>;
+			interrupt-parent = <&intc>;
+			interrupts = <50 IRQ_TYPE_LEVEL_HIGH>;
+			// trigger_error_index = <0x0201060c>;
+			ddrc_id = <3>;
+		};
+		ddrc@4 {
+			compatible = "sophgo,ddrc";
+
+			reg = <0x6b 0x70000000 0x00000000 0x04000000>;
+			interrupt-parent = <&intc>;
+			interrupts = <51 IRQ_TYPE_LEVEL_HIGH>;
+			// trigger_error_index = <0x0201060c>;
+			ddrc_id = <4>;
+		};
+		ddrc@5 {
+			compatible = "sophgo,ddrc";
+
+			reg = <0x6b 0x80000000 0x00000000 0x04000000>;
+			interrupt-parent = <&intc>;
+			interrupts = <52 IRQ_TYPE_LEVEL_HIGH>;
+			// trigger_error_index = <0x0201060c>;
+			ddrc_id = <5>;
+		};
+		ddrc@6 {
+			compatible = "sophgo,ddrc";
+
+			reg = <0x6b 0x84000000 0x00000000 0x04000000>;
+			interrupt-parent = <&intc>;
+			interrupts = <53 IRQ_TYPE_LEVEL_HIGH>;
+			// trigger_error_index = <0x0201060c>;
+			ddrc_id = <6>;
+		};
+		ddrc@7 {
+			compatible = "sophgo,ddrc";
+
+			reg = <0x6b 0x90000000 0x00000000 0x04000000>;
+			interrupt-parent = <&intc>;
+			interrupts = <54 IRQ_TYPE_LEVEL_HIGH>;
+			// trigger_error_index = <0x0201060c>;
+			ddrc_id = <7>;
 		};
 	};
 };

--- a/drivers/clk/sophgo/clk-bm1690e.c
+++ b/drivers/clk/sophgo/clk-bm1690e.c
@@ -209,7 +209,7 @@ static const struct sg2044_gate_clock bm1690e_gate_clks[] = {
 		CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED, 0x2000, 1, 0 },
 
 	{ GATE_CLK_TIMER1, "clk_gate_timer1", "clk_div_timer1",
-		CLK_SET_RATE_PARENT, 0x2000, 27, 0 },
+		CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED | CLK_IS_CRITICAL, 0x2000, 27, 0 },
 	{ GATE_CLK_TIMER2, "clk_gate_timer2", "clk_div_timer2",
 		CLK_SET_RATE_PARENT, 0x2000, 28, 0 },
 	{ GATE_CLK_TIMER3, "clk_gate_timer3", "clk_div_timer3",

--- a/drivers/clk/sophgo/clk-sg2044.c
+++ b/drivers/clk/sophgo/clk-sg2044.c
@@ -387,7 +387,7 @@ static const struct sg2044_gate_clock gate_clks[] = {
 	{ GATE_CLK_SC_RX_X0Y1, "clk_gate_sc_rx_x0y1", "clk_div_top_50m",
 		CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED, 0x2000, 13, 0 },
 	{ GATE_CLK_TIMER1, "clk_gate_timer1", "clk_div_timer1",
-		CLK_SET_RATE_PARENT, 0x2004, 8, 0 },
+		CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED | CLK_IS_CRITICAL, 0x2004, 8, 0 },
 	{ GATE_CLK_TIMER2, "clk_gate_timer2", "clk_div_timer2",
 		CLK_SET_RATE_PARENT, 0x2004, 9, 0 },
 	{ GATE_CLK_TIMER3, "clk_gate_timer3", "clk_div_timer3",


### PR DESCRIPTION
1. default enable clk for apb_timer1 in bm1690 and bm1690e.
2. format the uart4 in bm1690e-evb.dts.
3. add ddrc interrupt for bm1690e.