### PR TITLE
Fix python2 syntax in decode_msr.py

### DIFF
--- a/Documentation/trace/postprocess/decode_msr.py
+++ b/Documentation/trace/postprocess/decode_msr.py
@@ -32,6 +32,7 @@ for j in sys.stdin:
 					break
 		if r:
 			j = j.replace(" " + m.group(2), " " + r + "(" + m.group(2) + ")")
-	print j,
+	print (j, end=' ')
 
+print()
 


### PR DESCRIPTION
decode_msr.py seems not python3 compatible, it uses 'print j,' instead of 'print(j)'. 'print j,' is a python2 syntax.

These changes is for building rpm packages using openEuler kernel specs.