### PR TITLE
irqchip/sifive-plic: fix stuck in-progress IRQ on affinity migration

### DIFF
--- a/drivers/irqchip/irq-sifive-plic.c
+++ b/drivers/irqchip/irq-sifive-plic.c
@@ -154,14 +154,25 @@ static void plic_irq_disable(struct irq_data *d)
 static void plic_irq_eoi(struct irq_data *d)
 {
 	struct plic_handler *handler = this_cpu_ptr(&plic_handlers);
+	unsigned long flags;
+	void __iomem *reg = handler->enable_base + (d->hwirq / 32) * sizeof(u32);
+	u32 hwirq_mask = 1 << (d->hwirq % 32);
 
-	if (unlikely(irqd_irq_disabled(d))) {
-		plic_toggle(handler, d->hwirq, 1);
+	/*
+	 * PLIC drops a completion unless the source is enabled for this hart; a
+	 * dropped one leaves the interrupt stuck in-progress. Serialize against
+	 * plic_set_affinity() clearing the enable bit by holding enable_lock
+	 * across the EOI; re-enable around it if the bit was clear.
+	 */
+	raw_spin_lock_irqsave(&handler->enable_lock, flags);
+	if (unlikely(!(readl(reg) & hwirq_mask))) {
+		__plic_toggle(handler->enable_base, d->hwirq, 1);
 		writel(d->hwirq, handler->hart_base + CONTEXT_CLAIM);
-		plic_toggle(handler, d->hwirq, 0);
+		__plic_toggle(handler->enable_base, d->hwirq, 0);
 	} else {
 		writel(d->hwirq, handler->hart_base + CONTEXT_CLAIM);
 	}
+	raw_spin_unlock_irqrestore(&handler->enable_lock, flags);
 }
 
 #ifdef CONFIG_SMP


### PR DESCRIPTION
The PLIC silently drops a completion whose source is not enabled for the target hart. Until it receives a completion, it will not re-deliver the source. A dropped completion therefore leaves the source with no pending state, and the device stops receiving interrupts.

During affinity migration plic_set_affinity() clears the old hart's enable bit. If that lands between the old hart claiming the interrupt and writing its completion, the completion is dropped:

  CPU-A              PLIC             CPU-B
    |                 |                 |
    |--- claim ------>|                 |
    |                 |<-- clr en[A] ---|
    |                 |<-- eff -> B ----|
    |                 |<-- en[B] -------|
    |   run handler   |                 |
    |--- complete --->X                 |  dropped: not enabled on A
    |                 |                 |  source stuck (no pending)

For a direct PLIC IRQ, plic_irq_eoi() and plic_set_affinity() are both called under desc->lock and so cannot race. This serialization is absent for a PLIC IRQ that backs a chained irqchip: the completion is issued from chained_irq_exit() and plic_set_affinity() is reached via the chained chip's ->irq_set_affinity() callback, neither of which holds desc->lock.

plic_toggle() takes the per-context enable_lock when clearing the enable bit. Take the same lock across plic_irq_eoi() as well, so the affinity clear cannot overlap the EOI. Within the critical section, test the actual enable bit; if it is clear, re-enable the source, write the completion, and disable it again. enable_lock nests inside desc->lock, so taking it in the EOI path introduces no new lock ordering.